### PR TITLE
#15 GA event 함수 래핑 메서드 생성, Demo프로젝트를 'Fruit store'로 변경

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,10 +1,19 @@
 import React from "react";
 import NavBar from "./components/NavBar";
+import MainPage from "./pages/MainPage";
+import ProductsPage from "./pages/ProductsPage";
+import Route from "./router/Route";
 
 function App() {
   return (
     <div className="App">
       <NavBar />
+      <Route path="/">
+        <MainPage />
+      </Route>
+      <Route path="/products">
+        <ProductsPage />
+      </Route>
     </div>
   );
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import NavBar from "./components/NavBar";
 import MainPage from "./pages/MainPage";
 import ProductsPage from "./pages/ProductsPage";

--- a/demo/src/components/NavBar.tsx
+++ b/demo/src/components/NavBar.tsx
@@ -1,11 +1,52 @@
+import { logEvent } from "@every-analytics/react-analytics-provider";
+import React from "react";
+import navigate from "../router/navigate";
+
 const NavBar = () => {
   return (
     <header className="App-header">
-      <a href="/">Fruit Store</a>
-      <a href="/products?color=red">Red</a>
-      <a href="/products?color=yellow">Yellow</a>
+      <NavItem
+        href="/"
+        onClick={() => {
+          logEvent("Click logo");
+        }}
+      >
+        Fruit Store
+      </NavItem>
+      <NavItem
+        href="/products?color=red"
+        onClick={() => {
+          logEvent("Click nav item", { color: "red" });
+        }}
+      >
+        Red
+      </NavItem>
+      <NavItem
+        href="/products?color=yellow"
+        onClick={() => {
+          logEvent("Click logo", { color: "yellow" });
+        }}
+      >
+        Yellow
+      </NavItem>
     </header>
   );
+};
+
+const NavItem = ({
+  href,
+  children,
+  onClick,
+}: {
+  href: string;
+  children: React.ReactNode;
+  onClick?: (e: React.MouseEvent) => void;
+}) => {
+  const handleClick = (e: React.MouseEvent) => {
+    navigate.push(href);
+    onClick?.(e); // NOTE: prettier에서 에러로 인식하네?
+  };
+  return <button onClick={handleClick}>{children}</button>;
 };
 
 export default NavBar;

--- a/demo/src/components/NavBar.tsx
+++ b/demo/src/components/NavBar.tsx
@@ -1,8 +1,9 @@
 const NavBar = () => {
   return (
     <header className="App-header">
-      <a href="">HOME</a>
-      <a href="">ABOUT</a>
+      <a href="/">Fruit Store</a>
+      <a href="/products?color=red">Red</a>
+      <a href="/products?color=yellow">Yellow</a>
     </header>
   );
 };

--- a/demo/src/pages/MainPage/index.tsx
+++ b/demo/src/pages/MainPage/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const MainPage = () => {
+  return (
+    <>
+      <h1>Fruit Store</h1>
+    </>
+  );
+};
+
+export default MainPage;

--- a/demo/src/pages/ProductsPage/index.tsx
+++ b/demo/src/pages/ProductsPage/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { getQueryParams } from "../../utils/location";
+
+const ProductsPage = () => {
+  const { color } = getQueryParams<{ color: string }>();
+  const products = getProductsByColor(color);
+
+  return (
+    <>
+      <h1>{color} fruits</h1>
+      <ul>
+        {products.map((product) => (
+          <li>{product}</li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default ProductsPage;
+
+function getProductsByColor(color: string) {
+  switch (color) {
+    case "red":
+      return ["Strawberry", "Tomato"];
+    case "yellow":
+      return ["Banana", "Lemon"];
+    default:
+      return [];
+  }
+}

--- a/demo/src/pages/ProductsPage/index.tsx
+++ b/demo/src/pages/ProductsPage/index.tsx
@@ -10,7 +10,7 @@ const ProductsPage = () => {
       <h1>{color} fruits</h1>
       <ul>
         {products.map((product) => (
-          <li>{product}</li>
+          <li key={product}>{product}</li>
         ))}
       </ul>
     </>

--- a/demo/src/router/Route.ts
+++ b/demo/src/router/Route.ts
@@ -9,6 +9,7 @@ const Route = ({
 }) => {
   const [currentPath, setCurrentPath] = useState(window.location.pathname);
 
+  // FIXME: querystring이 바뀌어도 listening을 못함
   useEffect(() => {
     const onLocationChange = () => {
       setCurrentPath(window.location.pathname);

--- a/demo/src/router/Route.ts
+++ b/demo/src/router/Route.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const Route = ({
   path,
@@ -7,7 +7,19 @@ const Route = ({
   path: string;
   children: React.ReactElement;
 }) => {
-  return window.location.pathname === path ? children : null;
+  const [currentPath, setCurrentPath] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const onLocationChange = () => {
+      setCurrentPath(window.location.pathname);
+    };
+    window.addEventListener("popstate", onLocationChange);
+    return () => {
+      window.removeEventListener("popstate", onLocationChange);
+    };
+  }, []);
+
+  return currentPath === path ? children : null;
 };
 
 export default Route;

--- a/demo/src/router/Route.ts
+++ b/demo/src/router/Route.ts
@@ -1,0 +1,13 @@
+import React from "react";
+
+const Route = ({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactElement;
+}) => {
+  return window.location.pathname === path ? children : null;
+};
+
+export default Route;

--- a/demo/src/router/navigate.ts
+++ b/demo/src/router/navigate.ts
@@ -1,0 +1,9 @@
+function push(href: string) {
+  window.history.pushState({}, "", href);
+}
+
+const navigate = {
+  push,
+};
+
+export default navigate;

--- a/demo/src/router/navigate.ts
+++ b/demo/src/router/navigate.ts
@@ -1,5 +1,7 @@
 function push(href: string) {
   window.history.pushState({}, "", href);
+  const navEvent = new PopStateEvent("popstate");
+  window.dispatchEvent(navEvent);
 }
 
 const navigate = {

--- a/demo/src/utils/location.ts
+++ b/demo/src/utils/location.ts
@@ -1,6 +1,7 @@
+/**
+ * Returns query parameters with object type (e.g. ?color=red -> {color: 'red})
+ */
 export function getQueryParams<T extends { [k: string]: string }>(): T {
-  // const searchParams = new URLSearchParams(window.location.search);
-  // console.log({ searchParams });
   var search = window.location.search.substring(1);
   return JSON.parse(
     '{"' +

--- a/demo/src/utils/location.ts
+++ b/demo/src/utils/location.ts
@@ -2,7 +2,7 @@
  * Returns query parameters with object type (e.g. ?color=red -> {color: 'red})
  */
 export function getQueryParams<T extends { [k: string]: string }>(): T {
-  var search = window.location.search.substring(1);
+  const search = window.location.search.substring(1);
   return JSON.parse(
     '{"' +
       decodeURI(search)

--- a/demo/src/utils/location.ts
+++ b/demo/src/utils/location.ts
@@ -1,0 +1,13 @@
+export function getQueryParams<T extends { [k: string]: string }>(): T {
+  // const searchParams = new URLSearchParams(window.location.search);
+  // console.log({ searchParams });
+  var search = window.location.search.substring(1);
+  return JSON.parse(
+    '{"' +
+      decodeURI(search)
+        .replace(/"/g, '\\"')
+        .replace(/&/g, '","')
+        .replace(/=/g, '":"') +
+      '"}'
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,3 +19,4 @@ const SampleComponent = (props: IProps) => {
 
 export default SampleComponent;
 export * from "./components/AnalyticsProvider";
+export * from "./utils/googleAnalytics";

--- a/src/utils/googleAnalytics/event.ts
+++ b/src/utils/googleAnalytics/event.ts
@@ -1,0 +1,6 @@
+import { gtag } from "./initialize";
+
+export function logEvent(name: string, params?: { [key: string]: string }) {
+  console.info(`✅GA: event ${name}`, params);
+  gtag("event", name, params);
+}

--- a/src/utils/googleAnalytics/index.ts
+++ b/src/utils/googleAnalytics/index.ts
@@ -1,0 +1,2 @@
+export * from "./event";
+export * from "./initialize";

--- a/src/utils/googleAnalytics/initialize.ts
+++ b/src/utils/googleAnalytics/initialize.ts
@@ -4,7 +4,7 @@ declare global {
   }
 }
 
-export const gtag = function() {
+export const gtag = function(..._: any) {
   window.dataLayer.push(arguments);
 };
 
@@ -31,8 +31,6 @@ export const initializeGA = (
 
   window.dataLayer = window.dataLayer || [];
 
-  // @ts-ignore
   gtag("js", new Date());
-  // @ts-ignore
   gtag("config", trackingId, additionalConfigInfo);
 };

--- a/src/utils/googleAnalytics/initialize.ts
+++ b/src/utils/googleAnalytics/initialize.ts
@@ -9,14 +9,14 @@ export const gtag = function(..._: any) {
 };
 
 /**
- * Google Analytics를 초기화 합니다.
+ * Initialize google analytics
  */
 export const initializeGA = (
+  /** Tracking id (e.g. G-YNXXXXX) */
   trackingId: string,
-  additionalConfigInfo: any = {}
+  /** To set values that will be sent with every event for a web page */
+  persistentValues: any = {}
 ) => {
-  console.info(`✅GA(${trackingId})가 초기화 되었습니다.`);
-
   const scriptId = "ga-gtag";
 
   if (document.getElementById(scriptId)) return;
@@ -32,5 +32,6 @@ export const initializeGA = (
   window.dataLayer = window.dataLayer || [];
 
   gtag("js", new Date());
-  gtag("config", trackingId, additionalConfigInfo);
+  gtag("config", trackingId, persistentValues);
+  console.info(`📊Initialized Google Analytics (${trackingId}).`);
 };


### PR DESCRIPTION
## Description

### 1. Demo 프로젝트를 'Fruit store'로 변경
![image](https://user-images.githubusercontent.com/3839771/129453816-e0196ce9-3352-4e5a-b063-4332c38a8ecd.png)

이벤트 로깅 테스트하기 편하도록 UI를 만들었습니다

### 2. GA event 함수 생성
```
gtag("event", name, params);
```
를 감싸는 간단한 GA event 함수를 생성했습니다.

### 3. 라우팅이 바뀔때 페이지 리로드 막기
Before: 새 라우트로 가면 페이지 리로드
After: SPA방식



## Help Wanted 👀

(도움이 필요한 부분들을 적어주세요.)

## Related Issues

resolve #
fix #

## Checklist ✋

PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요.

- [ ] 모든 **변경점**들을 확인했으며 적절히 설명했습니다..
- [ ] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
