### PR TITLE
chore: eslint config 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,14 @@
 {
   "parser": "@typescript-eslint/parser", // eslint to TS
+  "plugins": ["prettier", "@typescript-eslint"],
   "extends": [
     "plugin:@typescript-eslint/recommended", // ts 추천 rules https://github.com/typescript-eslint/typescript-eslint#readme
-    "prettier/@typescript-eslint", // eslint rule과 prettier rule 충돌 방지. https://github.com/prettier/eslint-config-prettier
     "plugin:react/recommended", // react 추천 rules. https://github.com/yannickcr/eslint-plugin-react
     "plugin:react-hooks/recommended", // react-hook 추천 rules. https://github.com/facebook/react
     "plugin:jsx-a11y/recommended", // jsx 추천 rules. https://www.npmjs.com/package/eslint-plugin-jsx-a11y
     "plugin:import/errors", // es6+ import/export syntax linting 지원. https://www.npmjs.com/package/eslint-plugin-import
     "plugin:import/warnings", // es6+ import/export syntax linting 지원. https://www.npmjs.com/package/eslint-plugin-import
-    "plugin:prettier/recommended" // eslint의 formatting 기능을 prettier로 사용함. 항상 마지막에 세팅 되어야 함. https://github.com/prettier/eslint-config-prettier
+    "prettier" // eslint rule과 prettier rule 충돌 방지. https://github.com/prettier/eslint-config-prettier
   ],
   "parserOptions": {
     "ecmaVersion": 2018, // 문법 지원 (기본 값으로 둠)
@@ -16,6 +16,14 @@
   },
   "rules": {
     // custom 해야할 규칙 선언
+    "prettier/prettier": "error"
   },
-  "settings": {}
+  "settings": {
+    // module resolve issue로 인해 추가, https://stackoverflow.com/questions/55198502/using-eslint-with-typescript-unable-to-resolve-path-to-module
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    }
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   }


### PR DESCRIPTION
## Description
- eslint-prettier-plugin 이 제대로 적용되어 있지않아 수정하였습니다. ([참고](https://github.com/prettier/eslint-config-prettier#installation)) 
- eslint-config-prettier 의 적용이 업데이트 되지 않아, 수정하였습니다. ([참고](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21))
- 위 부분을 바로 잡은 이후에 `Unable to resolve path to module` 에러가 발생하여, 해당 에러를 해결하기 위해 settings 설정을 추가했습니다. ([참고](https://stackoverflow.com/questions/55198502/using-eslint-with-typescript-unable-to-resolve-path-to-module))
![image](https://user-images.githubusercontent.com/35516239/129473424-e5c1b806-2bfc-44fe-8ec1-2d15443e69e3.png)
(이전에 에러가 발생하지 않았던 이유는 eslint 세팅이 잘못되어서, vscode eslint exteionsion 이 초기 initialize 에 실패하여 작동하지 않았기 때문입니다.) 

### 결과 
- prettier 와 관련된 error 를 eslint 가 잡아내고, fix로 수정할 수 있게 됩니다. 이제 formatOnSave를 false로 해도 되며, eslint 가 formatting(prttier 역할)과 lint 를 동시에 담당하게 됩니다.


https://user-images.githubusercontent.com/35516239/129473523-7e5b51c6-082b-44dd-ab74-d9622a04a6b1.mov



## Help Wanted 👀

(도움이 필요한 부분들을 적어주세요.)

## Related Issues

resolve #28 
fix #28 

## Checklist ✋

PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요.

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다..
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
