### PR TITLE
Fix/84  eslint 관련 설정 변경, prettier script 삭제 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 /node_modules
 /build
-/demo

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 /node_modules
 /build
+/public
+/.next

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-# Ignore
-build
-node_modules
-
-# Ignore files
-*.html

--- a/demo/with-nextjs/.eslintrc.json
+++ b/demo/with-nextjs/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/demo/with-nextjs/next.config.js
+++ b/demo/with-nextjs/next.config.js
@@ -4,4 +4,4 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-}
+};

--- a/demo/with-nextjs/src/pages/_app.tsx
+++ b/demo/with-nextjs/src/pages/_app.tsx
@@ -1,6 +1,6 @@
-import type { AppProps } from 'next/app'
+import type {AppProps} from 'next/app';
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+function MyApp({Component, pageProps}: AppProps) {
+  return <Component {...pageProps} />;
 }
-export default MyApp
+export default MyApp;

--- a/demo/with-nextjs/src/pages/index.tsx
+++ b/demo/with-nextjs/src/pages/index.tsx
@@ -1,11 +1,7 @@
-import type { NextPage } from 'next'
+import type {NextPage} from 'next';
 
 const Home: NextPage = () => {
-  return (
-    <div>
-     Next Level
-    </div>
-  )
-}
+  return <div>Next Level</div>;
+};
 
-export default Home
+export default Home;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "module": "build/index.es.js",
   "jsnext:main": "build/index.es.js",
   "scripts": {
-    "format": "prettier --check . --ignore-path ./.prettierignore",
-    "format-fix": "prettier --write . --ignore-path ./.prettierignore",
     "lint": "eslint './**/*.+(js|ts)?(x)'",
+    "lint:fix": "eslint './**/*.+(js|ts)?(x)' --fix",
     "serve": "rollup -c rollup.config.js -w",
     "build": "rollup -c",
     "test": "jest",


### PR DESCRIPTION
## Description
- demo 폴더에 eslint 가 적용되지 않아 작업 중에 lint 에러가 있는 부분을 감지 하지 못함  예를 들면 https://github.com/EveryAnalytics/react-analytics-provider/issues/82 이런 이슈가 발생함 
- vscode eslint 플러그인을 활용하지 못해서 lint fix 명령어로 해당 부분을 해결하고 있었음 
- prettier format 이 더 이상 사용되지 않음에도 불구하고 script 파일에 있었음 
- demo 하위 폴더 까지 모두 공통된 eslint rule을 사용하도록 next 전용 eslint.rc 설정을 제거합니다. 

## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->

## Related Issues

resolve #
fix #84 

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
