### PR TITLE
feat/88 hide console in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-serve": "^1.1.0",
     "rollup-plugin-typescript2": "^0.24.3",
+    "@rollup/plugin-strip": "^2.1.0",
     "ts-jest": "^24.1.0",
     "typescript": "^3.9.10"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,12 @@ import external from 'rollup-plugin-peer-deps-external';
 import resolve from 'rollup-plugin-node-resolve';
 import serve from 'rollup-plugin-serve';
 import pkg from './package.json';
+import strip from '@rollup/plugin-strip';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx']; // 어떤 확장자를 처리 할 지 정함
+
+// Rollup Watch 기능(-w)이 동작하는 경우만 '개발 모드'라고 판단
+const production = !process.env.ROLLUP_WATCH;
 
 export default {
   input: 'src/index.tsx',
@@ -27,5 +31,9 @@ export default {
       include: ['node_modules/**'],
     }),
     serve('dist'),
+    production &&
+      strip({
+        include: '**/*.(ts|js)',
+      }),
   ],
 };


### PR DESCRIPTION
## Description

1. production 일 때 console.log 등이 안 보이도록 했습니다.
2. `rollup` plugin 중에 `strip` 을 사용하였습니다.
[refer](https://github.com/HeropCode/Svelte-Trello-app/blob/master/rollup.config.js#L130)

## Help Wanted 👀


## Related Issues

resolve #88 
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
