### PR TITLE
AnalyticsClick 구현

### DIFF
--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -24,9 +24,11 @@ const useClickInside = (
   );
 
   useEffect(() => {
-    document.addEventListener('click', handleClick);
+    const rootNode = document.getElementById('root');
+
+    rootNode?.addEventListener('click', handleClick);
     return () => {
-      document.removeEventListener('click', handleClick);
+      rootNode?.removeEventListener('click', handleClick);
     };
   }, [handleClick]);
 };

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -14,15 +14,11 @@ const useClickInside = (
   name: string,
   params?: UnknownRecord,
 ) => {
-  // if (!ref) {
-  //   return;
-  // }
-
   const handleClick = useCallback(e => {
     if (ref.current && ref.current.contains(e.target)) {
       callback(name, params);
     }
-  }, []);
+  }, [ref, name, params]);
 
   useEffect(() => {
     document.addEventListener('click', handleClick);
@@ -42,12 +38,7 @@ export const AnalyticsClick: FC<AnalyticsClickProps> = props => {
 
   return (
     <div ref={ref}>
-      {/* button */}
       {children}
     </div>
   );
 };
-
-// children 받기 => button
-// button wrapper의 ref 객체 접근
-// 버튼이 클릭되면 버블링 체크하여 ref에서 콜백함수(이벤트 호출) 실행

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, MutableRefObject, useCallback, useEffect, useRef} from 'react';
+import React, {FC, useCallback} from 'react';
 import {useAnalyticsContext} from '../../contexts';
 import {UnknownRecord} from '../../types/common';
 
@@ -8,36 +8,17 @@ export interface AnalyticsClickProps {
   params?: UnknownRecord;
 }
 
-const useClickInside = (
-  ref: MutableRefObject<HTMLDivElement | null>,
-  callback: (name: string, params?: UnknownRecord) => void,
-  name: string,
-  params?: UnknownRecord,
-) => {
-  const handleClick = useCallback(
-    e => {
-      if (ref.current && ref.current.contains(e.target)) {
-        callback(name, params);
-      }
-    },
-    [ref, name, params, callback],
-  );
-
-  useEffect(() => {
-    const rootNode = document.getElementById('root');
-
-    rootNode?.addEventListener('click', handleClick);
-    return () => {
-      rootNode?.removeEventListener('click', handleClick);
-    };
-  }, [handleClick]);
-};
-
-export const AnalyticsClick: FC = ({children, name, params}: AnalyticsClickProps) => {
-  const ref = useRef<HTMLDivElement | null>(null);
+export const AnalyticsClick: FC = (props: AnalyticsClickProps) => {
   const {onClick} = useAnalyticsContext();
+  const {children, name, params} = props;
 
-  useClickInside(ref, onClick, name, params);
+  const child = React.Children.only(children) as React.ReactElement;
 
-  return <div ref={ref}>{children}</div>;
+  const handleChildClick = useCallback(() => {
+    onClick(name, {action_type: 'click', ...params});
+  }, [name, params, onClick]);
+
+  return React.cloneElement(child, {
+    onClick: handleChildClick,
+  });
 };

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -20,7 +20,7 @@ const useClickInside = (
         callback(name, params);
       }
     },
-    [ref, name, params],
+    [ref, name, params, callback],
   );
 
   useEffect(() => {
@@ -28,12 +28,10 @@ const useClickInside = (
     return () => {
       document.removeEventListener('click', handleClick);
     };
-  }, []);
+  }, [handleClick]);
 };
 
-export const AnalyticsClick: FC<AnalyticsClickProps> = props => {
-  const {children, name, params} = props;
-
+export const AnalyticsClick: FC = ({children, name, params}: AnalyticsClickProps) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const {onClick} = useAnalyticsContext();
 

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -14,11 +14,14 @@ const useClickInside = (
   name: string,
   params?: UnknownRecord,
 ) => {
-  const handleClick = useCallback(e => {
-    if (ref.current && ref.current.contains(e.target)) {
-      callback(name, params);
-    }
-  }, [ref, name, params]);
+  const handleClick = useCallback(
+    e => {
+      if (ref.current && ref.current.contains(e.target)) {
+        callback(name, params);
+      }
+    },
+    [ref, name, params],
+  );
 
   useEffect(() => {
     document.addEventListener('click', handleClick);
@@ -36,9 +39,5 @@ export const AnalyticsClick: FC<AnalyticsClickProps> = props => {
 
   useClickInside(ref, onClick, name, params);
 
-  return (
-    <div ref={ref}>
-      {children}
-    </div>
-  );
+  return <div ref={ref}>{children}</div>;
 };

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -1,0 +1,53 @@
+import React, {FC, MutableRefObject, useCallback, useEffect, useRef} from 'react';
+import {useAnalyticsContext} from '../../contexts';
+import {UnknownRecord} from '../../types/common';
+
+export interface AnalyticsClickProps {
+  children: React.ReactNode;
+  name: string;
+  params?: UnknownRecord;
+}
+
+const useClickInside = (
+  ref: MutableRefObject<HTMLDivElement | null>,
+  callback: (name: string, params?: UnknownRecord) => void,
+  name: string,
+  params?: UnknownRecord,
+) => {
+  // if (!ref) {
+  //   return;
+  // }
+
+  const handleClick = useCallback(e => {
+    if (ref.current && ref.current.contains(e.target)) {
+      callback(name, params);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick);
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  }, []);
+};
+
+export const AnalyticsClick: FC<AnalyticsClickProps> = props => {
+  const {children, name, params} = props;
+
+  const ref = useRef<HTMLDivElement | null>(null);
+  const {onClick} = useAnalyticsContext();
+
+  useClickInside(ref, onClick, name, params);
+
+  return (
+    <div ref={ref}>
+      {/* button */}
+      {children}
+    </div>
+  );
+};
+
+// children 받기 => button
+// button wrapper의 ref 객체 접근
+// 버튼이 클릭되면 버블링 체크하여 ref에서 콜백함수(이벤트 호출) 실행

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './AnalyticsProvider';
 export * from './AnalyticsPageView';
+export * from './AnalyticsClick';


### PR DESCRIPTION
## Description

AnalyticsClick 컴포넌트의 하위 children으로 들어오는 엘리먼트를 useAnalyticsContext의 onCilck 함수를 props로 받은 새로운 엘리먼트로 만들어 반환합니다.

반환된 새 엘리먼트에 click 이벤트를 통해 onClick 함수가 호출되면 클릭 이벤트가 params와 함께 전송됩니다.

## Help Wanted 👀
React.Children.only(children) 함수의 반환 값이 React.ReactElement 타입으로 단언할 수 있는지 궁금합니다.

```ts
const child = React.Children.only(children) as React.ReactElement;
```

## Related Issues

resolve # 42
fix # 42

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
