### PR TITLE
feat: Refactor set function and implement setUserProperty function with demo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,8 @@
     "prettier/prettier": ["error", {"endOfLine":"auto"}],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/react-in-jsx-scope": "off",
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "jsx-a11y/no-onchange": "off"
   },
   "settings": {
     "react": {

--- a/demo/with-cra/src/App.tsx
+++ b/demo/with-cra/src/App.tsx
@@ -3,6 +3,7 @@ import MainPage from './pages/MainPage';
 import ProductsPage from './pages/ProductsPage';
 import LoginPage from './pages/LoginPage';
 import CurrencyPage from './pages/CurrencyPage';
+import UserPropertyPage from './pages/UserPropertyPage';
 import Route from './router/Route';
 
 function App() {
@@ -20,6 +21,9 @@ function App() {
       </Route>
       <Route path="/set-currency">
         <CurrencyPage />
+      </Route>
+      <Route path="/set-user-property">
+        <UserPropertyPage />
       </Route>
     </div>
   );

--- a/demo/with-cra/src/App.tsx
+++ b/demo/with-cra/src/App.tsx
@@ -2,6 +2,7 @@ import NavBar from './components/NavBar';
 import MainPage from './pages/MainPage';
 import ProductsPage from './pages/ProductsPage';
 import LoginPage from './pages/LoginPage';
+import CurrencyPage from './pages/CurrencyPage';
 import Route from './router/Route';
 
 function App() {
@@ -16,6 +17,9 @@ function App() {
       </Route>
       <Route path="/login">
         <LoginPage />
+      </Route>
+      <Route path="/set-currency">
+        <CurrencyPage />
       </Route>
     </div>
   );

--- a/demo/with-cra/src/components/NavBar.tsx
+++ b/demo/with-cra/src/components/NavBar.tsx
@@ -40,6 +40,14 @@ const NavBar = () => {
       >
         Login
       </NavItem>
+      <NavItem
+        href="/set-currency"
+        onClick={() => {
+          analytics.onSet({currency: 'KRW'});
+        }}
+      >
+        Currency
+      </NavItem>
     </header>
   );
 };

--- a/demo/with-cra/src/components/NavBar.tsx
+++ b/demo/with-cra/src/components/NavBar.tsx
@@ -48,6 +48,7 @@ const NavBar = () => {
       >
         Currency
       </NavItem>
+      <NavItem href="/set-user-property">UserProperty</NavItem>
     </header>
   );
 };

--- a/demo/with-cra/src/index.tsx
+++ b/demo/with-cra/src/index.tsx
@@ -34,6 +34,11 @@ ReactDOM.render(
         fruitLogger.click(name, params);
         toaster.click(name, params);
       }}
+      onSet={(...args: Parameters<typeof googleAnalytics.set>) => {
+        googleAnalytics.set(...args);
+        fruitLogger.set(...args);
+        toaster.set(...args);
+      }}
     >
       <App />
     </AnalyticsProvider>

--- a/demo/with-cra/src/index.tsx
+++ b/demo/with-cra/src/index.tsx
@@ -39,6 +39,11 @@ ReactDOM.render(
         fruitLogger.set(...args);
         toaster.set(...args);
       }}
+      onSetUserProperty={params => {
+        googleAnalytics.setUserProperty(params);
+        fruitLogger.setUserProperty(params);
+        toaster.setUserProperty(params);
+      }}
     >
       <App />
     </AnalyticsProvider>

--- a/demo/with-cra/src/pages/CurrencyPage/index.tsx
+++ b/demo/with-cra/src/pages/CurrencyPage/index.tsx
@@ -1,0 +1,13 @@
+import {useEffect} from 'react';
+import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+
+const CurrencyPage = () => {
+  const analytics = useAnalyticsContext();
+  useEffect(() => {
+    analytics.onPageView();
+  }, [analytics]);
+
+  return <h1>Set Currency KRW</h1>;
+};
+
+export default CurrencyPage;

--- a/demo/with-cra/src/pages/UserPropertyPage/index.tsx
+++ b/demo/with-cra/src/pages/UserPropertyPage/index.tsx
@@ -1,0 +1,33 @@
+import {useEffect, useState} from 'react';
+import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+
+const SetUserPropertyPage = () => {
+  const analytics = useAnalyticsContext();
+  useEffect(() => {
+    analytics.onPageView();
+  }, [analytics]);
+
+  const [favoriteFood, setFavoriteFood] = useState('한식');
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    analytics.onSetUserProperty({favoriteFood});
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <br />
+      <label>
+        Pick your favorite flavor:
+        <select value={favoriteFood} onChange={e => setFavoriteFood(e.target.value)}>
+          <option value="한식">한식</option>
+          <option value="중식">중식</option>
+          <option value="일식">일식</option>
+          <option value="양식">양식</option>
+        </select>
+      </label>
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+export default SetUserPropertyPage;

--- a/demo/with-cra/src/utils/fruitLogger/index.ts
+++ b/demo/with-cra/src/utils/fruitLogger/index.ts
@@ -1,15 +1,27 @@
-const pageView = (path: string, params?: {[key: string]: any}) => {
+type UnknownRecord = Record<string, unknown>;
+
+const pageView = (path: string, params?: UnknownRecord) => {
   console.info('🥝Fruit Logger - PageView', params);
 };
-const event = (name: string, params?: {[key: string]: any}) => {
+const event = (name: string, params?: UnknownRecord) => {
   console.info('🥝Fruit Logger - Event', name, params);
 };
-const click = (name: string, params?: {[key: string]: any}) => {
+const click = (name: string, params?: UnknownRecord) => {
   console.info('🥝Fruit Logger - Click', name, params);
+};
+const set = (...args: [string, UnknownRecord] | [UnknownRecord]) => {
+  const params = args.pop();
+  const name = args.pop();
+  if (name === undefined) {
+    console.info('🥝Fruit Logger - Set', params);
+  } else {
+    console.info('🥝Fruit Logger - Set', name, params);
+  }
 };
 
 export const fruitLogger = {
   pageView,
   event,
   click,
+  set,
 };

--- a/demo/with-cra/src/utils/fruitLogger/index.ts
+++ b/demo/with-cra/src/utils/fruitLogger/index.ts
@@ -18,10 +18,14 @@ const set = (...args: [string, UnknownRecord] | [UnknownRecord]) => {
     console.info('🥝Fruit Logger - Set', name, params);
   }
 };
+const setUserProperty = (params: UnknownRecord) => {
+  set('user_properties', params);
+};
 
 export const fruitLogger = {
   pageView,
   event,
   click,
   set,
+  setUserProperty,
 };

--- a/demo/with-cra/src/utils/toaster/index.tsx
+++ b/demo/with-cra/src/utils/toaster/index.tsx
@@ -47,9 +47,14 @@ export const set = (...args: [string, unknown] | [unknown]) => {
   );
 };
 
+export const setUserProperty = (params: unknown) => {
+  set('user_properties', params);
+};
+
 export const toaster = {
   event,
   click,
   pageView,
   set,
+  setUserProperty,
 };

--- a/demo/with-cra/src/utils/toaster/index.tsx
+++ b/demo/with-cra/src/utils/toaster/index.tsx
@@ -35,8 +35,21 @@ export const pageView = (path: string, params?: unknown) => {
   );
 };
 
+export const set = (...args: [string, unknown] | [unknown]) => {
+  const params = args.pop();
+  const name = args.pop();
+  showToast(
+    <>
+      <div>GA: Set</div>
+      {name && <div>name: {name}</div>}
+      <div>params: {JSON.stringify(params)}</div>
+    </>,
+  );
+};
+
 export const toaster = {
   event,
   click,
   pageView,
+  set,
 };

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
   onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  onSetUserProperty?(params: UnknownRecord): void;
   children: React.ReactNode;
 }
 
@@ -18,6 +19,7 @@ export function AnalyticsProvider({
   onEvent = () => null,
   onClick = () => null,
   onSet = () => null,
+  onSetUserProperty = () => null,
   children,
 }: Props) {
   React.useEffect(() => {
@@ -32,11 +34,12 @@ export function AnalyticsProvider({
           onEvent,
           onClick,
           onSet,
+          onSetUserProperty,
         }}
       >
         {children}
       </AnalyticsProviderContext.Provider>
     ),
-    [children, onClick, onEvent, onPageView, onSet],
+    [children, onClick, onEvent, onPageView, onSet, onSetUserProperty],
   );
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -8,8 +8,7 @@ interface Props {
   onPageView?(params?: UnknownRecord): void;
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
-  onSet?(name: string, params: UnknownRecord): void;
-  onSet?(params: UnknownRecord): void;
+  onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
   children: React.ReactNode;
 }
 

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -8,6 +8,8 @@ interface Props {
   onPageView?(params?: UnknownRecord): void;
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
+  onSet?(name: string, params: UnknownRecord): void;
+  onSet?(params: UnknownRecord): void;
   children: React.ReactNode;
 }
 
@@ -16,6 +18,7 @@ export function AnalyticsProvider({
   onPageView = () => null,
   onEvent = () => null,
   onClick = () => null,
+  onSet = () => null,
   children,
 }: Props) {
   React.useEffect(() => {
@@ -29,11 +32,12 @@ export function AnalyticsProvider({
           onPageView,
           onEvent,
           onClick,
+          onSet,
         }}
       >
         {children}
       </AnalyticsProviderContext.Provider>
     ),
-    [children, onClick, onEvent, onPageView],
+    [children, onClick, onEvent, onPageView, onSet],
   );
 }

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -5,12 +5,15 @@ export interface AnalyticsProviderContext {
   onPageView(params?: UnknownRecord): void;
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
+  onSet(name: string, params: UnknownRecord): void;
+  onSet(params: UnknownRecord): void;
 }
 
 export const initialState: AnalyticsProviderContext = {
   onPageView: () => null,
   onEvent: () => null,
   onClick: () => null,
+  onSet: () => null,
 };
 
 const AnalyticsProviderContext = createContext<AnalyticsProviderContext>(initialState);

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -5,8 +5,7 @@ export interface AnalyticsProviderContext {
   onPageView(params?: UnknownRecord): void;
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
-  onSet(name: string, params: UnknownRecord): void;
-  onSet(params: UnknownRecord): void;
+  onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
 }
 
 export const initialState: AnalyticsProviderContext = {

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -6,6 +6,7 @@ export interface AnalyticsProviderContext {
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
   onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  onSetUserProperty(params: UnknownRecord): void;
 }
 
 export const initialState: AnalyticsProviderContext = {
@@ -13,6 +14,7 @@ export const initialState: AnalyticsProviderContext = {
   onEvent: () => null,
   onClick: () => null,
   onSet: () => null,
+  onSetUserProperty: () => null,
 };
 
 const AnalyticsProviderContext = createContext<AnalyticsProviderContext>(initialState);

--- a/src/utils/googleAnalytics/index.ts
+++ b/src/utils/googleAnalytics/index.ts
@@ -2,10 +2,12 @@ import {event} from './event';
 import {click} from './click';
 import {initialize} from './initialize';
 import {set} from './set';
+import {setUserProperty} from './setUserProperty';
 
 export const googleAnalytics = {
   initialize,
   event,
   click,
   set,
+  setUserProperty,
 };

--- a/src/utils/googleAnalytics/set.ts
+++ b/src/utils/googleAnalytics/set.ts
@@ -5,9 +5,7 @@ import {gtag} from './initialize';
 /** Allows you to set values that persist across all the subsequent gtag() calls on the page.
  * {@link https://developers.google.com/gtagjs/reference/api#set API Reference}
  * @param params key-value pairs that are to persist across gtag() calls. */
-export function set(name: string, params: UnknownRecord): void;
-export function set(params: UnknownRecord): void;
-export function set(...args: unknown[]) {
+export function set(...args: [string, UnknownRecord] | [UnknownRecord]) {
   const params = args.pop();
   const name = args.pop();
   if (name === undefined) {

--- a/src/utils/googleAnalytics/set.ts
+++ b/src/utils/googleAnalytics/set.ts
@@ -14,7 +14,7 @@ export function set(...args: unknown[]) {
     console.info(`✅GA: set`, params);
     gtag('set', params);
   } else {
-    console.info(`✅GA: set`, name, params);
+    console.info(`✅GA: set ${name}`, params);
     gtag('set', name, params);
   }
 }

--- a/src/utils/googleAnalytics/set.ts
+++ b/src/utils/googleAnalytics/set.ts
@@ -5,7 +5,16 @@ import {gtag} from './initialize';
 /** Allows you to set values that persist across all the subsequent gtag() calls on the page.
  * {@link https://developers.google.com/gtagjs/reference/api#set API Reference}
  * @param params key-value pairs that are to persist across gtag() calls. */
-export function set(params: UnknownRecord) {
-  console.info(`✅GA: set`, params);
-  gtag('set', params);
+export function set(name: string, params: UnknownRecord): void;
+export function set(params: UnknownRecord): void;
+export function set(...args: unknown[]) {
+  const params = args.pop();
+  const name = args.pop();
+  if (name === undefined) {
+    console.info(`✅GA: set`, params);
+    gtag('set', params);
+  } else {
+    console.info(`✅GA: set`, name, params);
+    gtag('set', name, params);
+  }
 }

--- a/src/utils/googleAnalytics/setUserProperty.ts
+++ b/src/utils/googleAnalytics/setUserProperty.ts
@@ -1,0 +1,6 @@
+import {UnknownRecord} from '../../types/common';
+import {set} from './set';
+
+export function setUserProperty(params: UnknownRecord) {
+  return set('user_properties', params);
+}


### PR DESCRIPTION
## Description

제가 맡은 부분은 setUserProperty인데 [문서](https://developers.google.com/analytics/devguides/collection/ga4/user-properties) 에 보니 이런 형태더라구요.  
```
gtag('set', 'user_properties', {
  favorite_composer: 'Mahler',
  favorite_instrument: 'double bass',
  season_ticketholder: 'true'
});
```
일반적인(?) set은 아래처럼 params만 넘겨주는 형태인 것 같은데 user property나 [advertise feature를 disable](https://developers.google.com/analytics/devguides/collection/ga4/display-features)한다든지 몇몇 경우에 한해서 Name이 필요한 듯합니다. 
```
gtag('set', {
  'page_title': 'Travel Destinations',
  'currency': 'USD'
});
```
그래서 일단 기존에 params만 받도록 되어 있던 set 함수를 오버로딩해서 name도 받을 수 있게 추가했습니다. 여기선 name이 옵셔널이고 params가 필수라 오버로딩하지 않고 하려면 `set(params: UnknownRecord, name?: string)` 이렇게 해야하는데 다른 함수들은 전부 그 반대라 사용할 때 헷갈릴 것 같았거든요

**Update 8.29**

1. set function 다시 리팩토링
저번 커밋에서는 오버로딩을 사용해서 했었는데 실제 데모에서 적용하려고 보니까 오버로딩 함수는 parameter type을 뽑아내기가 어려운 문제가 있더라구요. Provider에서 넣어주는 onSet의 아규먼트를 googleAnalytics, fruitLogger 등의 함수에 rest parameter(...args)로 그대로 넘겨주려고 했는데 오버로딩된 타입을 인식을 제대로 못해서 에러가 납니다. (설명이...어렵네요..) 
   ts에 관련 [이슈](https://github.com/microsoft/TypeScript/issues/32164)가 있는데 아직 오픈 상태이고, [스택오버플로우](https://stackoverflow.com/questions/66190688/type-of-all-overload-parameter-types-in-typescript)에서 비슷한 문제 상황을 찾아서 tuple union 방식으로 다시 바꿨습니다. 만약 저희 타입스크립트 버전이 4.2 이상이었다면 이런 [문법](https://www.typescriptlang.org/docs/handbook/release-notes/overview.html#leadingmiddle-rest-elements-in-tuple-types)으로도 가능했을 것 같네요. 
2. set 함수 데모 추가 
3. setProperty 함수 추가 (위에 정의한 set 함수 이용)
4. setProperty 데모 추가

## Help Wanted 👀

<s>요거 괜찮으면 set사용해서 setUserProperty라는 함수 따로 또 만들고 Demo에도 예시 추가하는 작업하려고 합니다!</s>
피드백 부탁드립니다~

## Related Issues

resolve #70
resolve #162

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
