### PR TITLE
feat: onSetUserId 메서드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import {AnalyticsProvider} from '@every-analytics/react-analytics-provider';
   onPageView={(params) => console.log('pageview', params)}
   onEvent={(name, params) => console.log('event', name, params)}
   onClick={(name, params) => console.log('click', name, params)}
+  onSetUserId={(userId) => console.log('setUserId', userId)}
 >
   <App />
 </AnalyticsProvider>

--- a/demo/with-cra/src/index.tsx
+++ b/demo/with-cra/src/index.tsx
@@ -38,6 +38,10 @@ ReactDOM.render(
         fruitLogger.set(...args);
         toaster.set(...args);
       }}
+      onSetUserId={userId => {
+        // TODO: UserId 설정하는 코드 추가
+        console.log(userId);
+      }}
       onSetUserProperty={params => {
         googleAnalyticsHelper.setUserProperty(params);
         fruitLogger.setUserProperty(params);

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
   onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  onSetUserId?(userId: string | null): void;
   onSetUserProperty?(params: UnknownRecord): void;
   children: React.ReactNode;
 }
@@ -19,6 +20,7 @@ export function AnalyticsProvider({
   onEvent = () => null,
   onClick = () => null,
   onSet = () => null,
+  onSetUserId = () => null,
   onSetUserProperty = () => null,
   children,
 }: Props) {
@@ -34,12 +36,13 @@ export function AnalyticsProvider({
           onEvent,
           onClick,
           onSet,
+          onSetUserId,
           onSetUserProperty,
         }}
       >
         {children}
       </AnalyticsProviderContext.Provider>
     ),
-    [children, onClick, onEvent, onPageView, onSet, onSetUserProperty],
+    [children, onClick, onEvent, onPageView, onSet, onSetUserId, onSetUserProperty],
   );
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
   onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId?(userId: string | number | null): void;
+  onSetUserId?(userId: string | null): void;
   onSetUserProperty?(params: UnknownRecord): void;
   children: React.ReactNode;
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   onEvent?(name: string, params?: UnknownRecord): void;
   onClick?(name: string, params?: UnknownRecord): void;
   onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId?(userId: string | null): void;
+  onSetUserId?(userId: string | number | null): void;
   onSetUserProperty?(params: UnknownRecord): void;
   children: React.ReactNode;
 }

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -6,7 +6,7 @@ export interface AnalyticsProviderContext {
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
   onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId(userId: string | number | null): void;
+  onSetUserId(userId: string | null): void;
   onSetUserProperty(params: UnknownRecord): void;
 }
 

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -6,6 +6,7 @@ export interface AnalyticsProviderContext {
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
   onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  onSetUserId(userId: string | null): void;
   onSetUserProperty(params: UnknownRecord): void;
 }
 
@@ -14,6 +15,7 @@ export const initialState: AnalyticsProviderContext = {
   onEvent: () => null,
   onClick: () => null,
   onSet: () => null,
+  onSetUserId: () => null,
   onSetUserProperty: () => null,
 };
 

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -6,7 +6,7 @@ export interface AnalyticsProviderContext {
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
   onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId(userId: string | null): void;
+  onSetUserId(userId: string | number | null): void;
   onSetUserProperty(params: UnknownRecord): void;
 }
 


### PR DESCRIPTION
## Description

AnalyticsProviderContext에 onSetUserId 메서드를 추가합니다. UserId를 설정하는 방법은 Product Analytics(PA) 도구마다 다릅니다. 어떤 도구는 UserProperty에 설정하고, 어떤 도구는 별도 메서드를 제공하기도 합니다. 별도 메서드를 제공하는 PA를 지원하기 위해 setUserId 메서드를 추가합니다.

## Related Issues

resolve #112 

## Checklist ✋

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
