### PR TITLE
AnalyticClick props generic에 type 추가

### DIFF
--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useCallback} from 'react';
+import React, {useCallback} from 'react';
 import {useAnalyticsContext} from '../../contexts';
 import {UnknownRecord} from '../../types/common';
 
@@ -8,9 +8,8 @@ export interface AnalyticsClickProps {
   params?: UnknownRecord;
 }
 
-export const AnalyticsClick: FC = (props: AnalyticsClickProps) => {
+export const AnalyticsClick = ({children, name, params}: AnalyticsClickProps) => {
   const {onClick} = useAnalyticsContext();
-  const {children, name, params} = props;
 
   const child = React.Children.only(children) as React.ReactElement;
 


### PR DESCRIPTION
## Description
- AnalyticClick props generic에 type 추가
- Props generic이 정의되어 있지 않아 정상적으로 type checking이 되지 않고 있었음.

![1](https://user-images.githubusercontent.com/28521282/131000938-c7ffebf7-f62d-49c4-8ff6-28a178988c85.jpg)
![2](https://user-images.githubusercontent.com/28521282/131000955-b3cceab6-2eda-45cf-83bd-ed5867d245ff.jpg)



## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->

## Related Issues

resolve #
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
