### PR TITLE
test: googleAnalytics.initialize 테스트 추가

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: 'jsdom',
   moduleDirectories: ['node_modules'],
   testPathIgnorePatterns: ['/demo/', '/build/'],
+  restoreMocks: true,
 };

--- a/tests/utils/googleAnalytics/initialize.test.ts
+++ b/tests/utils/googleAnalytics/initialize.test.ts
@@ -5,34 +5,33 @@ import * as initUtils from '../../../src/utils/googleAnalytics/initialize';
 const SCRIPT_ID = 'ga-gtag';
 
 describe('googleAnalytics.initialize', () => {
-  let trackingId: string;
+  const setUp = () => {
+    const trackingId = faker.lorem.word();
 
-  let mockDate: Date;
-
-  let gtagSpy: jest.SpyInstance;
-
-  let getElementByIdSpy: jest.SpyInstance;
-  let createElementSpy: jest.SpyInstance;
-  let insertBeforeSpy: jest.SpyInstance;
-  let consoleInfoSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    trackingId = faker.lorem.word();
-
-    mockDate = faker.datatype.datetime();
+    const mockDate = faker.datatype.datetime();
     jest.useFakeTimers();
     jest.setSystemTime(mockDate);
 
-    gtagSpy = jest.spyOn(initUtils, 'gtag');
+    const gtagSpy = jest.spyOn(initUtils, 'gtag');
+    const getElementByIdSpy = jest.spyOn(document, 'getElementById');
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    const insertBeforeSpy = jest.spyOn(document, 'createElement');
+    const consoleInfoSpy = jest.spyOn(global.console, 'info');
 
-    getElementByIdSpy = jest.spyOn(document, 'getElementById');
-    createElementSpy = jest.spyOn(document, 'createElement');
-    insertBeforeSpy = jest.spyOn(document, 'createElement');
-    consoleInfoSpy = jest.spyOn(global.console, 'info');
-  });
+    return {
+      trackingId,
+      mockDate,
+      gtagSpy,
+      getElementByIdSpy,
+      createElementSpy,
+      insertBeforeSpy,
+      consoleInfoSpy,
+    };
+  };
 
   test('should return if script element already exists', () => {
-    getElementByIdSpy.mockReturnValue({innerHTML: 'EXIST'});
+    const {trackingId, getElementByIdSpy, createElementSpy} = setUp();
+    getElementByIdSpy.mockReturnValue({innerHTML: 'EXIST'} as HTMLElement);
 
     initUtils.initialize(trackingId);
 
@@ -41,6 +40,9 @@ describe('googleAnalytics.initialize', () => {
   });
 
   test('should create correct script element', () => {
+    const {trackingId, getElementByIdSpy, insertBeforeSpy, gtagSpy, consoleInfoSpy, mockDate, createElementSpy} =
+      setUp();
+
     initUtils.initialize(trackingId);
 
     expect(getElementByIdSpy).toHaveBeenCalledWith(SCRIPT_ID);

--- a/tests/utils/googleAnalytics/initialize.test.ts
+++ b/tests/utils/googleAnalytics/initialize.test.ts
@@ -37,7 +37,6 @@ describe('googleAnalytics.initialize', () => {
 
   test('should return if script element already exists', () => {
     getElementByIdSpy.mockReturnValue({innerHTML: 'EXIST'});
-    createElementSpy.mockImplementation(() => null);
 
     initUtils.initialize(trackingId);
 

--- a/tests/utils/googleAnalytics/initialize.test.ts
+++ b/tests/utils/googleAnalytics/initialize.test.ts
@@ -1,0 +1,65 @@
+import * as faker from 'faker';
+
+import * as initUtils from '../../../src/utils/googleAnalytics/initialize';
+
+const SCRIPT_ID = 'ga-gtag';
+
+describe('googleAnalytics.initialize', () => {
+  let trackingId: string;
+
+  let mockDate: Date;
+
+  let gtagSpy: jest.SpyInstance;
+
+  let getElementByIdSpy: jest.SpyInstance;
+  let createElementSpy: jest.SpyInstance;
+  let insertBeforeSpy: jest.SpyInstance;
+  let consoleInfoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    trackingId = faker.lorem.word();
+
+    mockDate = faker.datatype.datetime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    gtagSpy = jest.spyOn(initUtils, 'gtag');
+
+    getElementByIdSpy = jest.spyOn(document, 'getElementById');
+    createElementSpy = jest.spyOn(document, 'createElement');
+    insertBeforeSpy = jest.spyOn(document, 'createElement');
+    consoleInfoSpy = jest.spyOn(global.console, 'info');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should return if script element already exists', () => {
+    getElementByIdSpy.mockReturnValue({innerHTML: 'EXIST'});
+    createElementSpy.mockImplementation(() => null);
+
+    initUtils.initialize(trackingId);
+
+    expect(getElementByIdSpy).toHaveBeenCalledWith(SCRIPT_ID);
+    expect(createElementSpy).toBeCalledTimes(0);
+  });
+
+  test('should create correct script element', () => {
+    initUtils.initialize(trackingId);
+
+    expect(getElementByIdSpy).toHaveBeenCalledWith(SCRIPT_ID);
+    expect(createElementSpy).toHaveBeenCalledWith('script');
+    expect(insertBeforeSpy).toBeCalledTimes(1);
+
+    expect(gtagSpy).toHaveBeenNthCalledWith(1, 'js', mockDate);
+    expect(gtagSpy).toHaveBeenNthCalledWith(2, 'config', trackingId, undefined);
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+
+    const scriptElement = document.getElementById(SCRIPT_ID) as HTMLScriptElement;
+    expect(scriptElement.id).toEqual(SCRIPT_ID);
+    expect(scriptElement.type).toEqual('text/javascript');
+    expect(scriptElement.async).toEqual(true);
+    expect(scriptElement.src).toContain(trackingId);
+  });
+});

--- a/tests/utils/googleAnalytics/initialize.test.ts
+++ b/tests/utils/googleAnalytics/initialize.test.ts
@@ -31,10 +31,6 @@ describe('googleAnalytics.initialize', () => {
     consoleInfoSpy = jest.spyOn(global.console, 'info');
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   test('should return if script element already exists', () => {
     getElementByIdSpy.mockReturnValue({innerHTML: 'EXIST'});
 


### PR DESCRIPTION
## Description

정상적인 수행을 위해 #150 에서 설정된 패캐지/환경을 필요로 합니다.
위 PR이 머지되면 rebase 후 Ready for Review로 다시 돌리겠습니다!

<!-- 이 PR이 해결하는 문제. 기존의 기능을 변경한 경우, 1. 기존 기능의 작동, 2. 어떻게 고쳤는가, 3. 왜 고쳤는가를 포함해주세요. 필요에 따라 스크린샷도 첨부해주세요! -->
googleAnalytics helper의 initialize 함수에 대한 테스트를 작성했습니다.
같은 모듈 내의 gtag 함수는 구현이 간단해 테스트하지 않았습니다.

**느낀 점**
1. 단위 테스트를 작성하다보니 script element를 생성하는 로직과 gtag를 초기화하는 로직이 각각 분리되어 구현됐으면 좋았겠다는 생각이 들었습니다 ㅎㅎ 테스트 작성의 장점을 몸소 체감할 수 있어 좋은 경험이었습니다.
2. 검증 로직을 추가 구현해봐도 좋을 것 같다는 생각이 드네요!

## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->
### trackingId 검증
현재 initialize에서 딱히 trackingId의 format이나 길이는 검사하지 않고 있습니다.
그래서 테스트 코드에서도 `faker.lorem.word`로 아무 단어나 집어넣고 있습니다 😅 
이 부분이 조금 찜찜한데.. 다들 어떻게 생각하시나요?

### 테스트 분리 여부에 대한 고민
원래는 성공하는 case('should create correct script element')의 테스트를 
1. script element를 잘 생성하는가
2. gtag를 알맞은 파라미터로 호출하는가

2가지로 나눠서 작성하고 싶었는데, 이전 호출에서 Spy에 mocking된 값들이 뒤섞인건지 분리하면 자꾸 에러가 발생했습니다.. 😭 
이 테스트를 유지보수할 일이 많을 것 같진 않아 일단 그대로 뒀습니다. 허헣

(추가) 작동 시나리오가 "이미 있으면 생성 안 한다", "없으면 생성한다" 2가지니까 테스트도 지금처럼 2가지인게 맞는 것 같다는 생각이 문득 들었습니다.

## Related Issues

resolve #130 
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
