### PR TITLE
test: Add googleAnalytics.click test code

### DIFF
--- a/tests/utils/googleAnalytics/click.test.ts
+++ b/tests/utils/googleAnalytics/click.test.ts
@@ -4,6 +4,13 @@ import * as clickUtils from '../../../src/utils/googleAnalytics/click';
 
 describe('googleAnalytics.click', () => {
   const setUp = () => {
+    /**
+     *  Suppose GA is initialized
+     */
+    if (!window.dataLayer || !Array.isArray(window.dataLayer)) {
+      window.dataLayer = window.dataLayer ?? [];
+    }
+
     const name = faker.lorem.word();
     const params = {foo: 'bar'};
     const gtagSpy = jest.spyOn(initUtils, 'gtag');

--- a/tests/utils/googleAnalytics/click.test.ts
+++ b/tests/utils/googleAnalytics/click.test.ts
@@ -1,0 +1,41 @@
+import * as faker from 'faker';
+import * as initUtils from '../../../src/utils/googleAnalytics/initialize';
+import * as clickUtils from '../../../src/utils/googleAnalytics/click';
+
+describe('googleAnalytics.click', () => {
+  const setUp = () => {
+    const name = faker.lorem.word();
+    const params = {foo: 'bar'};
+    const gtagSpy = jest.spyOn(initUtils, 'gtag');
+    const consoleInfoSpy = jest.spyOn(global.console, 'info');
+
+    return {
+      name,
+      params,
+      gtagSpy,
+      consoleInfoSpy,
+    };
+  };
+
+  test('should record a click event with fake name', () => {
+    const {name, gtagSpy, consoleInfoSpy} = setUp();
+
+    clickUtils.click(name);
+
+    expect(consoleInfoSpy).toBeCalledTimes(1);
+    expect(consoleInfoSpy).toHaveBeenCalledWith(`✅GA: click ${name}`, {action_type: 'click'});
+    expect(gtagSpy).toBeCalledTimes(1);
+    expect(gtagSpy).toHaveBeenCalledWith('event', name, {action_type: 'click'});
+  });
+
+  test('should record a click event with fake name and params', () => {
+    const {name, params, gtagSpy, consoleInfoSpy} = setUp();
+
+    clickUtils.click(name, params);
+
+    expect(consoleInfoSpy).toBeCalledTimes(1);
+    expect(consoleInfoSpy).toHaveBeenCalledWith(`✅GA: click ${name}`, {action_type: 'click', ...params});
+    expect(gtagSpy).toBeCalledTimes(1);
+    expect(gtagSpy).toHaveBeenCalledWith('event', name, {action_type: 'click', ...params});
+  });
+});


### PR DESCRIPTION
* googleAnalytics.click 테스트 코드 추가
* relates to #133

## Description

googleAnalytics.click 함수에 대한 테스트 코드입니다.
함수 내 주요 함수인 console.info와 gtag 함수를 모킹하여 정상적으로 인자가 들어가는지 확인하였습니다.

click 함수에 대한 테스트 코드인 만큼 initialize 작업을 아래와 같이 대체하였습니다.

```ts
    if (!window.dataLayer || !Array.isArray(window.dataLayer)) {
      window.dataLayer = window.dataLayer ?? [];
    }
```

## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->

faker 라이브러리로 모킹 객체를 만드는 방법이 있는지 조사가 필요합니다.
현재는 {foo: 'bar'} 로 적용하였습니다.

## Related Issues

resolve # 133
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
- [x] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)