### PR TITLE
test: Update googleAnalytics/click gtag mocking

### DIFF
--- a/tests/utils/googleAnalytics/click.test.ts
+++ b/tests/utils/googleAnalytics/click.test.ts
@@ -4,16 +4,9 @@ import * as clickUtils from '../../../src/utils/googleAnalytics/click';
 
 describe('googleAnalytics.click', () => {
   const setUp = () => {
-    /**
-     *  Suppose GA is initialized
-     */
-    if (!window.dataLayer || !Array.isArray(window.dataLayer)) {
-      window.dataLayer = window.dataLayer ?? [];
-    }
-
     const name = faker.lorem.word();
     const params = {foo: 'bar'};
-    const gtagSpy = jest.spyOn(initUtils, 'gtag');
+    const gtagSpy = jest.spyOn(initUtils, 'gtag').mockImplementation(() => null);
     const consoleInfoSpy = jest.spyOn(console, 'info');
 
     return {


### PR DESCRIPTION
* 테스트 대상이 아닌 함수의 의존성 제거
* relates to #168 #174

## Description

기존 gtag과 initialize 함수에 의해 발생하던 의존성 문제를 해결
gtag 함수를 mockImplementation 으로 의존성 제거

## Help Wanted 👀

## Related Issues

resolve #174
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
- [x] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)