### PR TITLE
fix: Update .yarnrc.yml to resolve wallaby-jest runtime deps issue

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -13611,6 +13611,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-jasmine2", "npm:22.4.4"],
             ["jest-regex-util", "npm:22.4.3"],
             ["jest-resolve", "npm:22.4.3"],
+            ["jest-runtime", "npm:27.1.0"],
             ["jest-util", "npm:22.4.3"],
             ["jest-validate", "npm:22.4.4"],
             ["pretty-format", "npm:22.4.3"]
@@ -13631,6 +13632,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-jasmine2", "npm:23.6.0"],
             ["jest-regex-util", "npm:23.3.0"],
             ["jest-resolve", "npm:23.6.0"],
+            ["jest-runtime", "npm:27.1.0"],
             ["jest-util", "npm:23.4.0"],
             ["jest-validate", "npm:23.6.0"],
             ["micromatch", "npm:2.3.11"],
@@ -13667,6 +13669,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-regex-util", "npm:27.0.6"],
             ["jest-resolve", "npm:27.1.0"],
             ["jest-runner", "npm:27.1.0"],
+            ["jest-runtime", "npm:27.1.0"],
             ["jest-util", "npm:27.1.0"],
             ["jest-validate", "npm:27.1.0"],
             ["micromatch", "npm:4.0.4"],

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,8 @@ plugins:
     spec: "@yarnpkg/plugin-typescript"
 
 yarnPath: .yarn/releases/yarn-berry.cjs
+
+packageExtensions:
+  jest-config@*:
+    dependencies:
+      jest-runtime: "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10823,38 +10823,7 @@ fsevents@1.2.4:
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:^23.6.0":
-  version: 23.6.0
-  resolution: "jest-runtime@npm:23.6.0"
-  dependencies:
-    babel-core: ^6.0.0
-    babel-plugin-istanbul: ^4.1.6
-    chalk: ^2.0.1
-    convert-source-map: ^1.4.0
-    exit: ^0.1.2
-    fast-json-stable-stringify: ^2.0.0
-    graceful-fs: ^4.1.11
-    jest-config: ^23.6.0
-    jest-haste-map: ^23.6.0
-    jest-message-util: ^23.4.0
-    jest-regex-util: ^23.3.0
-    jest-resolve: ^23.6.0
-    jest-snapshot: ^23.6.0
-    jest-util: ^23.4.0
-    jest-validate: ^23.6.0
-    micromatch: ^2.3.11
-    realpath-native: ^1.0.0
-    slash: ^1.0.0
-    strip-bom: 3.0.0
-    write-file-atomic: ^2.1.0
-    yargs: ^11.0.0
-  bin:
-    jest-runtime: ./bin/jest-runtime.js
-  checksum: 4eacd27dc2f4ec1cb17aed6626acb2e95eddea51b8b0ba618ca7cf4136d7e55e699f134609e332b70a48c01b2737bf96e241c3eef7abe062921be8a308d6188b
-  languageName: node
-  linkType: hard
-
-"jest-runtime@npm:^27.1.0":
+"jest-runtime@npm:*, jest-runtime@npm:^27.1.0":
   version: 27.1.0
   resolution: "jest-runtime@npm:27.1.0"
   dependencies:
@@ -10886,6 +10855,37 @@ fsevents@1.2.4:
     strip-bom: ^4.0.0
     yargs: ^16.0.3
   checksum: 83c090763a0b0b269eba5736d70016db2a5984010e9f974bd037bcf7746c09d4e064c83da8b34048dbcd2c029d28cc49a7ac7d547b406f9b46fdd0428b77f2e5
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^23.6.0":
+  version: 23.6.0
+  resolution: "jest-runtime@npm:23.6.0"
+  dependencies:
+    babel-core: ^6.0.0
+    babel-plugin-istanbul: ^4.1.6
+    chalk: ^2.0.1
+    convert-source-map: ^1.4.0
+    exit: ^0.1.2
+    fast-json-stable-stringify: ^2.0.0
+    graceful-fs: ^4.1.11
+    jest-config: ^23.6.0
+    jest-haste-map: ^23.6.0
+    jest-message-util: ^23.4.0
+    jest-regex-util: ^23.3.0
+    jest-resolve: ^23.6.0
+    jest-snapshot: ^23.6.0
+    jest-util: ^23.4.0
+    jest-validate: ^23.6.0
+    micromatch: ^2.3.11
+    realpath-native: ^1.0.0
+    slash: ^1.0.0
+    strip-bom: 3.0.0
+    write-file-atomic: ^2.1.0
+    yargs: ^11.0.0
+  bin:
+    jest-runtime: ./bin/jest-runtime.js
+  checksum: 4eacd27dc2f4ec1cb17aed6626acb2e95eddea51b8b0ba618ca7cf4136d7e55e699f134609e332b70a48c01b2737bf96e241c3eef7abe062921be8a308d6188b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* yarn2에서 발생하는 wallaby-jest 의존성 이슈 해결
* relates to #197

## Description

* yarn2 사용 시 발생하는 wallaby-jest-runtime 의존성 찾지 못하는 이슈 해결
* yarnrc.yml 내 packageExtenstions 섹션 추가

## Help Wanted 👀

## Related Issues

resolve #197 

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`yarn build`, `yarn test`)
- [x] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)