### PR TITLE
feat: amplitudeHelper.setUserId Feature & TC 구현

### DIFF
--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -1,5 +1,6 @@
 import {initialize} from './initialize';
 import {logEvent} from './logEvent';
 import {Revenue, logRevenueV2} from './logRevenueV2';
+import {setUserId} from './setUserId';
 
-export const amplitudeHelper = {initialize, logEvent, Revenue, logRevenueV2};
+export const amplitudeHelper = {initialize, logEvent, Revenue, logRevenueV2, setUserId};

--- a/src/utils/amplitude/setUserId.ts
+++ b/src/utils/amplitude/setUserId.ts
@@ -2,12 +2,12 @@ import amplitude from 'amplitude-js';
 
 export const setUserId = (userId: string | null) => {
   if (userId !== null && !userId) {
-    console.warn('userId is required for setUserId');
+    console.info('userId is required for setUserId');
     return;
   }
 
   if (typeof userId !== 'string' && userId !== null) {
-    console.warn('userId must be a string or null');
+    console.info('userId must be string or null');
     return;
   }
 

--- a/src/utils/amplitude/setUserId.ts
+++ b/src/utils/amplitude/setUserId.ts
@@ -1,6 +1,15 @@
 import amplitude from 'amplitude-js';
 
 export const setUserId = (userId: string | null) => {
-  const userId_ = userId === '' || userId === null ? null : userId
-  amplitude.getInstance().setUserId(userId_)
+  if (userId !== null && !userId) {
+    console.warn('userId is required for setUserId');
+    return;
+  }
+
+  if (typeof userId !== 'string' && userId !== null) {
+    console.warn('userId must be a string or null');
+    return;
+  }
+
+  amplitude.getInstance().setUserId(userId);
 };

--- a/src/utils/amplitude/setUserId.ts
+++ b/src/utils/amplitude/setUserId.ts
@@ -1,0 +1,6 @@
+import amplitude from 'amplitude-js';
+
+export const setUserId = (userId: string | null) => {
+  const userId_ = userId === '' || userId === null ? null : userId
+  amplitude.getInstance().setUserId(userId_)
+};

--- a/src/utils/amplitude/setUserId.ts
+++ b/src/utils/amplitude/setUserId.ts
@@ -2,7 +2,7 @@ import {getInstance} from 'amplitude-js';
 
 export const setUserId = (userId: string | null) => {
   if (typeof userId !== 'string' && userId !== null) {
-    console.info('userId must be string or null');
+    console.warn('userId must be string or null');
     return;
   }
 

--- a/src/utils/amplitude/setUserId.ts
+++ b/src/utils/amplitude/setUserId.ts
@@ -1,15 +1,10 @@
-import amplitude from 'amplitude-js';
+import {getInstance} from 'amplitude-js';
 
 export const setUserId = (userId: string | null) => {
-  if (userId !== null && !userId) {
-    console.info('userId is required for setUserId');
-    return;
-  }
-
   if (typeof userId !== 'string' && userId !== null) {
     console.info('userId must be string or null');
     return;
   }
 
-  amplitude.getInstance().setUserId(userId);
+  getInstance().setUserId(userId);
 };

--- a/tests/utils/amplitude/setUserId.test.ts
+++ b/tests/utils/amplitude/setUserId.test.ts
@@ -22,38 +22,6 @@ describe('amplitudeHelper.setUserId', () => {
     };
   };
 
-  test('should warn if setUserId is called with falsy value', () => {
-    const {consoleWarnSpy, getInstanceSpy} = setUp();
-    const warning = 'userId is required for setUserId';
-
-    setUserIdUtils.setUserId('');
-    setUserIdUtils.setUserId(undefined as any);
-    setUserIdUtils.setUserId(false as any);
-    setUserIdUtils.setUserId(0 as any);
-
-    expect(consoleWarnSpy).toBeCalledTimes(4);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(2, warning);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(3, warning);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(4, warning);
-    expect(getInstanceSpy).toBeCalledTimes(0);
-  });
-
-  test('should warn if setUserId is called with incorrect Type', () => {
-    const {consoleWarnSpy, getInstanceSpy} = setUp();
-    const warning = 'userId must be string or null';
-
-    setUserIdUtils.setUserId(9999 as any);
-    setUserIdUtils.setUserId({} as any);
-    setUserIdUtils.setUserId(new Function() as any);
-
-    expect(consoleWarnSpy).toBeCalledTimes(3);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(2, warning);
-    expect(consoleWarnSpy).toHaveBeenNthCalledWith(3, warning);
-    expect(getInstanceSpy).toBeCalledTimes(0);
-  });
-
   test(`should call amplitude setUserId with null userId`, () => {
     const {consoleWarnSpy, getInstanceSpy, amplitudeSetUserIdMock} = setUp();
     const userId = null;

--- a/tests/utils/amplitude/setUserId.test.ts
+++ b/tests/utils/amplitude/setUserId.test.ts
@@ -5,12 +5,12 @@ import * as setUserIdUtils from '../../../src/utils/amplitude/setUserId';
 describe('amplitudeHelper.setUserId', () => {
   const setUp = () => {
     const userId = faker.lorem.word();
-    const consoleWarnSpy = jest.spyOn(console, 'warn');
+    const consoleWarnSpy = jest.spyOn(console, 'info');
     const amplitudeSetUserIdMock = jest.fn()
     const getInstanceSpy = jest.spyOn(amplitude, 'getInstance').mockImplementation(
       () => ({
         setUserId: amplitudeSetUserIdMock
-      })
+      }) as any
     )
 
     return {
@@ -26,9 +26,9 @@ describe('amplitudeHelper.setUserId', () => {
     const warning = 'userId is required for setUserId'
 
     setUserIdUtils.setUserId('')
-    setUserIdUtils.setUserId(undefined)
-    setUserIdUtils.setUserId(false)
-    setUserIdUtils.setUserId(0)
+    setUserIdUtils.setUserId(undefined as any)
+    setUserIdUtils.setUserId(false as any)
+    setUserIdUtils.setUserId(0 as any)
 
     expect(consoleWarnSpy).toBeCalledTimes(4);
     expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
@@ -40,11 +40,11 @@ describe('amplitudeHelper.setUserId', () => {
 
   test('should warn if setUserId is called with incorrect Type', () => {
     const {consoleWarnSpy, getInstanceSpy} = setUp();
-    const warning = 'userId must be a string or null'
+    const warning = 'userId must be string or null'
 
-    setUserIdUtils.setUserId(9999)
-    setUserIdUtils.setUserId({})
-    setUserIdUtils.setUserId(() => {})
+    setUserIdUtils.setUserId(9999 as any)
+    setUserIdUtils.setUserId({} as any)
+    setUserIdUtils.setUserId(new Function() as any)
 
     expect(consoleWarnSpy).toBeCalledTimes(3);
     expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
@@ -55,13 +55,14 @@ describe('amplitudeHelper.setUserId', () => {
 
   test(`should call amplitude setUserId with null userId`, () => {
     const {consoleWarnSpy, getInstanceSpy, amplitudeSetUserIdMock} = setUp();
+    const userId = null;
 
-    setUserIdUtils.setUserId(null)
+    setUserIdUtils.setUserId(userId)
 
     expect(consoleWarnSpy).toBeCalledTimes(0);
     expect(getInstanceSpy).toBeCalledTimes(1);
     expect(getInstanceSpy).toHaveBeenCalledWith();
-    expect(amplitudeSetUserIdMock).toHaveBeenCalledWith(null);
+    expect(amplitudeSetUserIdMock).toHaveBeenCalledWith(userId);
   });
 
   test(`should call amplitude setUserId with string userId`, () => {

--- a/tests/utils/amplitude/setUserId.test.ts
+++ b/tests/utils/amplitude/setUserId.test.ts
@@ -1,0 +1,24 @@
+import * as faker from 'faker';
+import * as initUtils from '../../../src/utils/googleAnalytics/initialize';
+import * as clickUtils from '../../../src/utils/googleAnalytics/click';
+
+describe('amplitudeHelper.setUserId', () => {
+  const setUp = () => {
+    const name = faker.lorem.word();
+
+    return {
+      name,
+    };
+  };
+
+  test('should set a click event with fake name', () => {
+    const {name, gtagSpy, consoleInfoSpy} = setUp();
+
+    clickUtils.click(name);
+
+    expect(consoleInfoSpy).toBeCalledTimes(1);
+    expect(consoleInfoSpy).toHaveBeenCalledWith(`✅GA: click ${name}`, {action_type: 'click'});
+    expect(gtagSpy).toBeCalledTimes(1);
+    expect(gtagSpy).toHaveBeenCalledWith('event', name, {action_type: 'click'});
+  });
+});

--- a/tests/utils/amplitude/setUserId.test.ts
+++ b/tests/utils/amplitude/setUserId.test.ts
@@ -6,12 +6,13 @@ describe('amplitudeHelper.setUserId', () => {
   const setUp = () => {
     const userId = faker.lorem.word();
     const consoleWarnSpy = jest.spyOn(console, 'info');
-    const amplitudeSetUserIdMock = jest.fn()
+    const amplitudeSetUserIdMock = jest.fn();
     const getInstanceSpy = jest.spyOn(amplitude, 'getInstance').mockImplementation(
-      () => ({
-        setUserId: amplitudeSetUserIdMock
-      }) as any
-    )
+      () =>
+        ({
+          setUserId: amplitudeSetUserIdMock,
+        } as any),
+    );
 
     return {
       userId,
@@ -23,12 +24,12 @@ describe('amplitudeHelper.setUserId', () => {
 
   test('should warn if setUserId is called with falsy value', () => {
     const {consoleWarnSpy, getInstanceSpy} = setUp();
-    const warning = 'userId is required for setUserId'
+    const warning = 'userId is required for setUserId';
 
-    setUserIdUtils.setUserId('')
-    setUserIdUtils.setUserId(undefined as any)
-    setUserIdUtils.setUserId(false as any)
-    setUserIdUtils.setUserId(0 as any)
+    setUserIdUtils.setUserId('');
+    setUserIdUtils.setUserId(undefined as any);
+    setUserIdUtils.setUserId(false as any);
+    setUserIdUtils.setUserId(0 as any);
 
     expect(consoleWarnSpy).toBeCalledTimes(4);
     expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
@@ -40,11 +41,11 @@ describe('amplitudeHelper.setUserId', () => {
 
   test('should warn if setUserId is called with incorrect Type', () => {
     const {consoleWarnSpy, getInstanceSpy} = setUp();
-    const warning = 'userId must be string or null'
+    const warning = 'userId must be string or null';
 
-    setUserIdUtils.setUserId(9999 as any)
-    setUserIdUtils.setUserId({} as any)
-    setUserIdUtils.setUserId(new Function() as any)
+    setUserIdUtils.setUserId(9999 as any);
+    setUserIdUtils.setUserId({} as any);
+    setUserIdUtils.setUserId(new Function() as any);
 
     expect(consoleWarnSpy).toBeCalledTimes(3);
     expect(consoleWarnSpy).toHaveBeenNthCalledWith(1, warning);
@@ -57,7 +58,7 @@ describe('amplitudeHelper.setUserId', () => {
     const {consoleWarnSpy, getInstanceSpy, amplitudeSetUserIdMock} = setUp();
     const userId = null;
 
-    setUserIdUtils.setUserId(userId)
+    setUserIdUtils.setUserId(userId);
 
     expect(consoleWarnSpy).toBeCalledTimes(0);
     expect(getInstanceSpy).toBeCalledTimes(1);
@@ -68,7 +69,7 @@ describe('amplitudeHelper.setUserId', () => {
   test(`should call amplitude setUserId with string userId`, () => {
     const {userId, consoleWarnSpy, getInstanceSpy, amplitudeSetUserIdMock} = setUp();
 
-    setUserIdUtils.setUserId(userId)
+    setUserIdUtils.setUserId(userId);
 
     expect(consoleWarnSpy).toBeCalledTimes(0);
     expect(getInstanceSpy).toBeCalledTimes(1);

--- a/tests/utils/amplitude/setUserId.test.ts
+++ b/tests/utils/amplitude/setUserId.test.ts
@@ -5,7 +5,7 @@ import * as setUserIdUtils from '../../../src/utils/amplitude/setUserId';
 describe('amplitudeHelper.setUserId', () => {
   const setUp = () => {
     const userId = faker.lorem.word();
-    const consoleWarnSpy = jest.spyOn(console, 'info');
+    const consoleWarnSpy = jest.spyOn(console, 'warn');
     const amplitudeSetUserIdMock = jest.fn();
     const getInstanceSpy = jest.spyOn(amplitude, 'getInstance').mockImplementation(
       () =>


### PR DESCRIPTION
## Description

* 앰플리튜드 setUserId 함수와 테스트 코드 구현
* 앰플리튜드 타이핑에 맞게 userId로는 string 과 null을 받도록 타이핑
* string or null 외에는 warn 콘솔 안내 후 함수 종료

## Help Wanted 👀

## Related Issues

resolve #192 

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`yarn build`, `yarn test`)
- [x] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)