### PR TITLE
refactor: change RAP interface design

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can check examples [here](https://github.com/EveryAnalytics/react-analytics-
 import {Analytics, AnalyticsProvider} from '@every-analytics/react-analytics-provider';
 
 const analytics: Analytics = {
+  initialize: () => console.log('onInitialize'),
   trackPageView: params => console.log('onTrackPageView', params),
   trackEvent: (name, params) => console.log('onTrackEvent', name, params),
   trackClick: (name, params) => console.log('onTrackClick', name, params),

--- a/README.md
+++ b/README.md
@@ -40,14 +40,20 @@ yarn add @every-analytics/react-analytics-provider
 You can check examples [here](https://github.com/EveryAnalytics/react-analytics-provider/tree/main/demo)
 
 ```tsx
-import {AnalyticsProvider} from '@every-analytics/react-analytics-provider';
+import {Analytics, AnalyticsProvider} from '@every-analytics/react-analytics-provider';
+
+const analytics: Analytics = {
+  trackPageView: params => console.log('onTrackPageView', params),
+  trackEvent: (name, params) => console.log('onTrackEvent', name, params),
+  trackClick: (name, params) => console.log('onTrackClick', name, params),
+  set: (...args) => console.log('onSet', args),
+  setUserId: userId => console.log("onSetUserId", userId),
+  setUserProperty: params => console.log("onSetUserProperty", params),
+}
 
 <AnalyticsProvider
   onInitialize={() => console.log('initialized')}
-  onPageView={(params) => console.log('pageview', params)}
-  onEvent={(name, params) => console.log('event', name, params)}
-  onClick={(name, params) => console.log('click', name, params)}
-  onSetUserId={(userId) => console.log('setUserId', userId)}
+  analytics={analytics}
 >
   <App />
 </AnalyticsProvider>

--- a/demo/with-cra/src/components/NavBar.tsx
+++ b/demo/with-cra/src/components/NavBar.tsx
@@ -1,10 +1,10 @@
 // import { logEvent } from "@every-analytics/react-analytics-provider";
 import React from 'react';
 import navigate from 'router/navigate';
-import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+import {useAnalytics} from '@every-analytics/react-analytics-provider';
 
 const NavBar = () => {
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
 
   return (
     <header className="App-header">

--- a/demo/with-cra/src/components/NavBar.tsx
+++ b/demo/with-cra/src/components/NavBar.tsx
@@ -11,7 +11,7 @@ const NavBar = () => {
       <NavItem
         href="/"
         onClick={() => {
-          analytics.onEvent('Click logo');
+          analytics.trackEvent('Click logo');
         }}
       >
         Fruit Store
@@ -19,7 +19,7 @@ const NavBar = () => {
       <NavItem
         href="/products?color=red"
         onClick={() => {
-          analytics.onEvent('Click products', {color: 'red'});
+          analytics.trackEvent('Click products', {color: 'red'});
         }}
       >
         Red
@@ -27,7 +27,7 @@ const NavBar = () => {
       <NavItem
         href="/products?color=yellow"
         onClick={() => {
-          analytics.onEvent('Click products', {color: 'yellow'});
+          analytics.trackEvent('Click products', {color: 'yellow'});
         }}
       >
         Yellow
@@ -35,7 +35,7 @@ const NavBar = () => {
       <NavItem
         href="/login"
         onClick={() => {
-          analytics.onClick('Click login', {color: 'yellow'});
+          analytics.trackClick('Click login', {color: 'yellow'});
         }}
       >
         Login
@@ -43,7 +43,7 @@ const NavBar = () => {
       <NavItem
         href="/set-currency"
         onClick={() => {
-          analytics.onSet({currency: 'KRW'});
+          analytics.set({currency: 'KRW'});
         }}
       >
         Currency

--- a/demo/with-cra/src/index.tsx
+++ b/demo/with-cra/src/index.tsx
@@ -16,6 +16,9 @@ amplitudeHelper.initialize(process.env.REACT_APP_AMPLITUDE_API_KEY);
 const persistentValues = {userNo: 123};
 
 const analytics: Analytics = {
+  initialize: () => {
+    googleAnalyticsHelper.initialize(process.env.REACT_APP_GA_TRACKING_ID, persistentValues);
+  },
   trackPageView: params => {
     // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
     const path = window.location.pathname + window.location.search;
@@ -51,12 +54,7 @@ const analytics: Analytics = {
 
 ReactDOM.render(
   <React.StrictMode>
-    <AnalyticsProvider
-      onInitialize={() => {
-        googleAnalyticsHelper.initialize(process.env.REACT_APP_GA_TRACKING_ID, persistentValues);
-      }}
-      analytics={analytics}
-    >
+    <AnalyticsProvider analytics={analytics}>
       <App />
     </AnalyticsProvider>
     <Toaster

--- a/demo/with-cra/src/index.tsx
+++ b/demo/with-cra/src/index.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import {AnalyticsProvider, googleAnalyticsHelper, amplitudeHelper} from '@every-analytics/react-analytics-provider';
+import {
+  Analytics,
+  AnalyticsProvider,
+  googleAnalyticsHelper,
+  amplitudeHelper,
+} from '@every-analytics/react-analytics-provider';
 import {fruitLogger} from './utils/fruitLogger';
 import {Toaster} from 'react-hot-toast';
 import {toaster} from './utils/toaster';
@@ -10,43 +15,47 @@ import {toaster} from './utils/toaster';
 amplitudeHelper.initialize(process.env.REACT_APP_AMPLITUDE_API_KEY);
 const persistentValues = {userNo: 123};
 
+const analytics: Analytics = {
+  trackPageView: params => {
+    // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
+    const path = window.location.pathname + window.location.search;
+    fruitLogger.pageView(path, params);
+    toaster.pageView(path, params);
+    amplitudeHelper.logEvent('pageView', {path});
+  },
+  trackEvent: (name, params) => {
+    googleAnalyticsHelper.event(name, params);
+    fruitLogger.event(name, params);
+    toaster.event(name, params);
+  },
+  trackClick: (name, params) => {
+    googleAnalyticsHelper.click(name, params);
+    fruitLogger.click(name, params);
+    toaster.click(name, params);
+  },
+  set: (...args: Parameters<typeof googleAnalyticsHelper.set>) => {
+    googleAnalyticsHelper.set(...args);
+    fruitLogger.set(...args);
+    toaster.set(...args);
+  },
+  setUserId: userId => {
+    // TODO: UserId 설정하는 코드 추가
+    console.log(userId);
+  },
+  setUserProperty: params => {
+    googleAnalyticsHelper.setUserProperty(params);
+    fruitLogger.setUserProperty(params);
+    toaster.setUserProperty(params);
+  },
+};
+
 ReactDOM.render(
   <React.StrictMode>
     <AnalyticsProvider
       onInitialize={() => {
         googleAnalyticsHelper.initialize(process.env.REACT_APP_GA_TRACKING_ID, persistentValues);
       }}
-      onPageView={params => {
-        // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
-        const path = window.location.pathname + window.location.search;
-        fruitLogger.pageView(path, params);
-        toaster.pageView(path, params);
-        amplitudeHelper.logEvent('pageView', {path});
-      }}
-      onEvent={(name, params) => {
-        googleAnalyticsHelper.event(name, params);
-        fruitLogger.event(name, params);
-        toaster.event(name, params);
-      }}
-      onClick={(name, params) => {
-        googleAnalyticsHelper.click(name, params);
-        fruitLogger.click(name, params);
-        toaster.click(name, params);
-      }}
-      onSet={(...args: Parameters<typeof googleAnalyticsHelper.set>) => {
-        googleAnalyticsHelper.set(...args);
-        fruitLogger.set(...args);
-        toaster.set(...args);
-      }}
-      onSetUserId={userId => {
-        // TODO: UserId 설정하는 코드 추가
-        console.log(userId);
-      }}
-      onSetUserProperty={params => {
-        googleAnalyticsHelper.setUserProperty(params);
-        fruitLogger.setUserProperty(params);
-        toaster.setUserProperty(params);
-      }}
+      analytics={analytics}
     >
       <App />
     </AnalyticsProvider>

--- a/demo/with-cra/src/pages/CurrencyPage/index.tsx
+++ b/demo/with-cra/src/pages/CurrencyPage/index.tsx
@@ -1,8 +1,8 @@
 import {useEffect} from 'react';
-import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+import {useAnalytics} from '@every-analytics/react-analytics-provider';
 
 const CurrencyPage = () => {
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
   useEffect(() => {
     analytics.onPageView();
   }, [analytics]);

--- a/demo/with-cra/src/pages/CurrencyPage/index.tsx
+++ b/demo/with-cra/src/pages/CurrencyPage/index.tsx
@@ -4,7 +4,7 @@ import {useAnalytics} from '@every-analytics/react-analytics-provider';
 const CurrencyPage = () => {
   const analytics = useAnalytics();
   useEffect(() => {
-    analytics.onPageView();
+    analytics.trackPageView();
   }, [analytics]);
 
   return <h1>Set Currency KRW</h1>;

--- a/demo/with-cra/src/pages/ProductsPage/index.tsx
+++ b/demo/with-cra/src/pages/ProductsPage/index.tsx
@@ -1,11 +1,11 @@
 import {useEffect} from 'react';
 import {getQueryParams} from 'utils/location';
-import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+import {useAnalytics} from '@every-analytics/react-analytics-provider';
 
 const ProductsPage = () => {
   const {color} = getQueryParams<{color: string}>();
   const products = getProductsByColor(color);
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
 
   useEffect(() => {
     analytics.onPageView();

--- a/demo/with-cra/src/pages/ProductsPage/index.tsx
+++ b/demo/with-cra/src/pages/ProductsPage/index.tsx
@@ -8,7 +8,7 @@ const ProductsPage = () => {
   const analytics = useAnalytics();
 
   useEffect(() => {
-    analytics.onPageView();
+    analytics.trackPageView();
   }, [analytics]);
 
   return (

--- a/demo/with-cra/src/pages/UserPropertyPage/index.tsx
+++ b/demo/with-cra/src/pages/UserPropertyPage/index.tsx
@@ -1,8 +1,8 @@
 import {useEffect, useState} from 'react';
-import {useAnalyticsContext} from '@every-analytics/react-analytics-provider';
+import {useAnalytics} from '@every-analytics/react-analytics-provider';
 
 const SetUserPropertyPage = () => {
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
   useEffect(() => {
     analytics.onPageView();
   }, [analytics]);

--- a/demo/with-cra/src/pages/UserPropertyPage/index.tsx
+++ b/demo/with-cra/src/pages/UserPropertyPage/index.tsx
@@ -4,13 +4,13 @@ import {useAnalytics} from '@every-analytics/react-analytics-provider';
 const SetUserPropertyPage = () => {
   const analytics = useAnalytics();
   useEffect(() => {
-    analytics.onPageView();
+    analytics.trackPageView();
   }, [analytics]);
 
   const [favoriteFood, setFavoriteFood] = useState('한식');
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    analytics.onSetUserProperty({favoriteFood});
+    analytics.setUserProperty({favoriteFood});
   };
 
   return (

--- a/demo/with-nextjs/src/pages/_app.tsx
+++ b/demo/with-nextjs/src/pages/_app.tsx
@@ -4,6 +4,9 @@ import {Layout} from '../layout/Layout';
 
 function DemoApp({Component, pageProps}: AppProps) {
   const analytics: Analytics = {
+    initialize: () => {
+      console.log('onInitialize');
+    },
     trackPageView: params => {
       // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
       // TODO: 이준희 => ga, amplitude event tracking 코드 추가
@@ -29,13 +32,7 @@ function DemoApp({Component, pageProps}: AppProps) {
   };
 
   return (
-    <AnalyticsProvider
-      onInitialize={() => {
-        // TODO: 이준희 => ga, amplitude event tracking 코드 추가
-        console.log('onInitialize');
-      }}
-      analytics={analytics}
-    >
+    <AnalyticsProvider analytics={analytics}>
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/demo/with-nextjs/src/pages/_app.tsx
+++ b/demo/with-nextjs/src/pages/_app.tsx
@@ -1,27 +1,40 @@
-import {AnalyticsProvider} from '@every-analytics/react-analytics-provider';
+import {Analytics, AnalyticsProvider} from '@every-analytics/react-analytics-provider';
 import {AppProps} from 'next/app';
 import {Layout} from '../layout/Layout';
 
 function DemoApp({Component, pageProps}: AppProps) {
+  const analytics: Analytics = {
+    trackPageView: params => {
+      // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
+      // TODO: 이준희 => ga, amplitude event tracking 코드 추가
+      console.log('onTrackPageView', params);
+    },
+    trackEvent: (name, params) => {
+      // TODO: 이준희 => ga, amplitude event tracking 코드 추가
+      console.log('onTrackEvent', name, params);
+    },
+    trackClick: (name, params) => {
+      // TODO: 이준희 => ga, amplitude event tracking 코드 추가
+      console.log('onTrackClick', name, params);
+    },
+    set: (...args) => {
+      console.log('onSet', args);
+    },
+    setUserId: userId => {
+      console.log('onSetUserId', userId);
+    },
+    setUserProperty: params => {
+      console.log('onSetUserProperty', params);
+    },
+  };
+
   return (
     <AnalyticsProvider
       onInitialize={() => {
         // TODO: 이준희 => ga, amplitude event tracking 코드 추가
         console.log('onInitialize');
       }}
-      onPageView={params => {
-        // NOTE: Google Analytics(GA4)는 기본적으로 페이지뷰가 적용됩니다 - 따로 추가 필요X
-        // TODO: 이준희 => ga, amplitude event tracking 코드 추가
-        console.log('onPageView', params);
-      }}
-      onEvent={(name, params) => {
-        // TODO: 이준희 => ga, amplitude event tracking 코드 추가
-        console.log('onEvent', name, params);
-      }}
-      onClick={(name, params) => {
-        // TODO: 이준희 => ga, amplitude event tracking 코드 추가
-        console.log('onClick', name, params);
-      }}
+      analytics={analytics}
     >
       <Layout>
         <Component {...pageProps} />

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -9,13 +9,13 @@ export interface AnalyticsClickProps {
 }
 
 export const AnalyticsClick = ({children, name, params}: AnalyticsClickProps) => {
-  const {onClick} = useAnalytics();
+  const {trackClick} = useAnalytics();
 
   const child = React.Children.only(children) as React.ReactElement;
 
   const handleChildClick = useCallback(() => {
-    onClick(name, {action_type: 'click', ...params});
-  }, [name, params, onClick]);
+    trackClick(name, {action_type: 'click', ...params});
+  }, [name, params, trackClick]);
 
   return React.cloneElement(child, {
     onClick: handleChildClick,

--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {useAnalyticsContext} from '../../contexts';
+import {useAnalytics} from '../../contexts';
 import {UnknownRecord} from '../../types/common';
 
 export interface AnalyticsClickProps {
@@ -9,7 +9,7 @@ export interface AnalyticsClickProps {
 }
 
 export const AnalyticsClick = ({children, name, params}: AnalyticsClickProps) => {
-  const {onClick} = useAnalyticsContext();
+  const {onClick} = useAnalytics();
 
   const child = React.Children.only(children) as React.ReactElement;
 

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useAnalyticsContext} from '../../contexts/useAnalyticsContext';
+import {useAnalytics} from '../../contexts/useAnalytics';
 import {UnknownRecord} from '../../types/common';
 
 export interface AnalyticsPageViewProps {
@@ -8,7 +8,7 @@ export interface AnalyticsPageViewProps {
 }
 
 export const AnalyticsPageView = ({children, params}: AnalyticsPageViewProps) => {
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
 
   React.useEffect(() => {
     analytics.onPageView(params);

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -11,7 +11,7 @@ export const AnalyticsPageView = ({children, params}: AnalyticsPageViewProps) =>
   const analytics = useAnalytics();
 
   React.useEffect(() => {
-    analytics.onPageView(params);
+    analytics.trackPageView(params);
   }, [analytics, params]);
 
   return <>{children}</>;

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -32,12 +32,12 @@ export function AnalyticsProvider({
     () => (
       <AnalyticsProviderContext.Provider
         value={{
-          onPageView,
-          onEvent,
-          onClick,
-          onSet,
-          onSetUserId,
-          onSetUserProperty,
+          trackPageView: onPageView,
+          trackEvent: onEvent,
+          trackClick: onClick,
+          set: onSet,
+          setUserId: onSetUserId,
+          setUserProperty: onSetUserProperty,
         }}
       >
         {children}

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -4,19 +4,14 @@ import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
 import {Analytics} from '../../core';
 
 interface Props {
-  onInitialize(): void;
   analytics: Analytics;
   children: React.ReactNode;
 }
 
-export function AnalyticsProvider({
-  onInitialize,
-  analytics,
-  children,
-}: Props) {
+export function AnalyticsProvider({analytics, children}: Props) {
   React.useEffect(() => {
-    onInitialize();
-  }, [onInitialize]);
+    analytics.initialize();
+  }, [analytics]);
 
   return React.useMemo(
     () => <AnalyticsProviderContext.Provider value={analytics}>{children}</AnalyticsProviderContext.Provider>,

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -1,27 +1,17 @@
 import * as React from 'react';
 
 import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
-import {UnknownRecord} from '../../types/common';
+import {Analytics} from '../../core';
 
 interface Props {
   onInitialize(): void;
-  onPageView?(params?: UnknownRecord): void;
-  onEvent?(name: string, params?: UnknownRecord): void;
-  onClick?(name: string, params?: UnknownRecord): void;
-  onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId?(userId: string | null): void;
-  onSetUserProperty?(params: UnknownRecord): void;
+  analytics: Analytics;
   children: React.ReactNode;
 }
 
 export function AnalyticsProvider({
   onInitialize,
-  onPageView = () => null,
-  onEvent = () => null,
-  onClick = () => null,
-  onSet = () => null,
-  onSetUserId = () => null,
-  onSetUserProperty = () => null,
+  analytics,
   children,
 }: Props) {
   React.useEffect(() => {
@@ -29,20 +19,7 @@ export function AnalyticsProvider({
   }, [onInitialize]);
 
   return React.useMemo(
-    () => (
-      <AnalyticsProviderContext.Provider
-        value={{
-          trackPageView: onPageView,
-          trackEvent: onEvent,
-          trackClick: onClick,
-          set: onSet,
-          setUserId: onSetUserId,
-          setUserProperty: onSetUserProperty,
-        }}
-      >
-        {children}
-      </AnalyticsProviderContext.Provider>
-    ),
-    [children, onClick, onEvent, onPageView, onSet, onSetUserId, onSetUserProperty],
+    () => <AnalyticsProviderContext.Provider value={analytics}>{children}</AnalyticsProviderContext.Provider>,
+    [children, analytics],
   );
 }

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -1,16 +1,7 @@
 import {createContext} from 'react';
-import {UnknownRecord} from '../types/common';
+import {Analytics} from '../core';
 
-export interface Analytics {
-  onPageView(params?: UnknownRecord): void;
-  onEvent(name: string, params?: UnknownRecord): void;
-  onClick(name: string, params?: UnknownRecord): void;
-  onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId(userId: string | null): void;
-  onSetUserProperty(params: UnknownRecord): void;
-}
-
-export const initialState: Analytics = {
+const initialState: Analytics = {
   onPageView: () => null,
   onEvent: () => null,
   onClick: () => null,

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -2,6 +2,7 @@ import {createContext} from 'react';
 import {Analytics} from '../core';
 
 const initialState: Analytics = {
+  initialize: () => null,
   trackPageView: () => null,
   trackEvent: () => null,
   trackClick: () => null,

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -1,7 +1,7 @@
 import {createContext} from 'react';
 import {UnknownRecord} from '../types/common';
 
-export interface AnalyticsProviderContext {
+export interface Analytics {
   onPageView(params?: UnknownRecord): void;
   onEvent(name: string, params?: UnknownRecord): void;
   onClick(name: string, params?: UnknownRecord): void;
@@ -10,7 +10,7 @@ export interface AnalyticsProviderContext {
   onSetUserProperty(params: UnknownRecord): void;
 }
 
-export const initialState: AnalyticsProviderContext = {
+export const initialState: Analytics = {
   onPageView: () => null,
   onEvent: () => null,
   onClick: () => null,
@@ -19,6 +19,6 @@ export const initialState: AnalyticsProviderContext = {
   onSetUserProperty: () => null,
 };
 
-const AnalyticsProviderContext = createContext<AnalyticsProviderContext>(initialState);
+const AnalyticsProviderContext = createContext<Analytics>(initialState);
 
 export default AnalyticsProviderContext;

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -2,12 +2,12 @@ import {createContext} from 'react';
 import {Analytics} from '../core';
 
 const initialState: Analytics = {
-  onPageView: () => null,
-  onEvent: () => null,
-  onClick: () => null,
-  onSet: () => null,
-  onSetUserId: () => null,
-  onSetUserProperty: () => null,
+  trackPageView: () => null,
+  trackEvent: () => null,
+  trackClick: () => null,
+  set: () => null,
+  setUserId: () => null,
+  setUserProperty: () => null,
 };
 
 const AnalyticsProviderContext = createContext<Analytics>(initialState);

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,1 @@
-export * from './useAnalyticsContext';
+export * from './useAnalytics';

--- a/src/contexts/useAnalytics.ts
+++ b/src/contexts/useAnalytics.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import AnalyticsProviderContext from './AnalyticsProviderContext';
 
-export function useAnalyticsContext() {
+export function useAnalytics() {
   return React.useContext(AnalyticsProviderContext);
 }

--- a/src/core/Analytics.ts
+++ b/src/core/Analytics.ts
@@ -1,0 +1,10 @@
+import {UnknownRecord} from '../types/common';
+
+export interface Analytics {
+  onPageView(params?: UnknownRecord): void;
+  onEvent(name: string, params?: UnknownRecord): void;
+  onClick(name: string, params?: UnknownRecord): void;
+  onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  onSetUserId(userId: string | null): void;
+  onSetUserProperty(params: UnknownRecord): void;
+}

--- a/src/core/Analytics.ts
+++ b/src/core/Analytics.ts
@@ -1,6 +1,7 @@
 import {UnknownRecord} from '../types/common';
 
 export interface Analytics {
+  initialize(): void;
   trackPageView(params?: UnknownRecord): void;
   trackEvent(name: string, params?: UnknownRecord): void;
   trackClick(name: string, params?: UnknownRecord): void;

--- a/src/core/Analytics.ts
+++ b/src/core/Analytics.ts
@@ -1,10 +1,10 @@
 import {UnknownRecord} from '../types/common';
 
 export interface Analytics {
-  onPageView(params?: UnknownRecord): void;
-  onEvent(name: string, params?: UnknownRecord): void;
-  onClick(name: string, params?: UnknownRecord): void;
-  onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId(userId: string | null): void;
-  onSetUserProperty(params: UnknownRecord): void;
+  trackPageView(params?: UnknownRecord): void;
+  trackEvent(name: string, params?: UnknownRecord): void;
+  trackClick(name: string, params?: UnknownRecord): void;
+  set(...args: [string, UnknownRecord] | [UnknownRecord]): void;
+  setUserId(userId: string | null): void;
+  setUserProperty(params: UnknownRecord): void;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,1 @@
+export * from './Analytics';

--- a/src/hooks/useAnalyticsPageView.ts
+++ b/src/hooks/useAnalyticsPageView.ts
@@ -10,7 +10,7 @@ export function useAnalyticsPageView(paramsOrCallback: UnknownRecord | (() => Pr
 
   const pageView = async () => {
     const params = typeof paramsOrCallback === 'function' ? await paramsOrCallback() : paramsOrCallback;
-    analytics.onPageView(params);
+    analytics.trackPageView(params);
   };
 
   React.useEffect(() => {

--- a/src/hooks/useAnalyticsPageView.ts
+++ b/src/hooks/useAnalyticsPageView.ts
@@ -1,12 +1,12 @@
 import React from 'react';
-import {useAnalyticsContext} from '../contexts/useAnalyticsContext';
+import {useAnalytics} from '../contexts/useAnalytics';
 import {UnknownRecord} from '../types/common';
 
 export function useAnalyticsPageView(params: UnknownRecord): void;
 export function useAnalyticsPageView(callback: () => UnknownRecord): void;
 export function useAnalyticsPageView(callback: () => Promise<UnknownRecord>): void;
 export function useAnalyticsPageView(paramsOrCallback: UnknownRecord | (() => Promise<UnknownRecord> | UnknownRecord)) {
-  const analytics = useAnalyticsContext();
+  const analytics = useAnalytics();
 
   const pageView = async () => {
     const params = typeof paramsOrCallback === 'function' ? await paramsOrCallback() : paramsOrCallback;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,3 +2,4 @@ export * from './components';
 export * from './utils';
 export * from './contexts';
 export * from './hooks';
+export * from './core';

--- a/tests/hooks/useAnalyticsPageView.test.ts
+++ b/tests/hooks/useAnalyticsPageView.test.ts
@@ -10,13 +10,13 @@ describe('useAnalyticsPageView', () => {
     const callback = () => params;
     const asyncCallback = async () => params;
 
-    const onPageView = jest.fn();
+    const trackPageView = jest.fn();
 
     const useEffectSpy = jest.spyOn(React, 'useEffect').mockImplementationOnce(cb => cb());
     const useContextSpy = jest.spyOn(contextModule, 'useAnalytics').mockImplementationOnce(
       () =>
         ({
-          onPageView,
+          trackPageView,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any),
     );
@@ -26,7 +26,7 @@ describe('useAnalyticsPageView', () => {
       params,
       callback,
       asyncCallback,
-      onPageView,
+      trackPageView,
       useEffectSpy,
       useContextSpy,
     };
@@ -34,36 +34,36 @@ describe('useAnalyticsPageView', () => {
 
   const waitForAsync = () => new Promise(resolve => setTimeout(resolve, 0));
 
-  test('should call analytics.onPageView with params', async () => {
-    const {params, onPageView, useContextSpy, useEffectSpy} = setUp();
+  test('should call analytics.trackPageView with params', async () => {
+    const {params, trackPageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(params);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(trackPageView).toHaveBeenCalledWith(params);
   });
 
-  test('should call analytics.onPageView with callback', async () => {
-    const {params, callback, onPageView, useContextSpy, useEffectSpy} = setUp();
+  test('should call analytics.trackPageView with callback', async () => {
+    const {params, callback, trackPageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(callback);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(trackPageView).toHaveBeenCalledWith(params);
   });
 
-  test('should call analytics.onPageView with asyncCallback', async () => {
-    const {params, asyncCallback, onPageView, useContextSpy, useEffectSpy} = setUp();
+  test('should call analytics.trackPageView with asyncCallback', async () => {
+    const {params, asyncCallback, trackPageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(asyncCallback);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(trackPageView).toHaveBeenCalledWith(params);
   });
 });

--- a/tests/hooks/useAnalyticsPageView.test.ts
+++ b/tests/hooks/useAnalyticsPageView.test.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as faker from 'faker';
 
-import * as contextModule from '../../src/contexts/useAnalyticsContext';
+import * as contextModule from '../../src/contexts/useAnalytics';
 import {useAnalyticsPageView} from '../../src/hooks/useAnalyticsPageView';
 
 describe('useAnalyticsPageView', () => {
@@ -13,7 +13,7 @@ describe('useAnalyticsPageView', () => {
     const onPageView = jest.fn();
 
     const useEffectSpy = jest.spyOn(React, 'useEffect').mockImplementationOnce(cb => cb());
-    const useContextSpy = jest.spyOn(contextModule, 'useAnalyticsContext').mockImplementationOnce(
+    const useContextSpy = jest.spyOn(contextModule, 'useAnalytics').mockImplementationOnce(
       () =>
         ({
           onPageView,


### PR DESCRIPTION
## Description

<!-- 이 PR이 해결하는 문제. 기존의 기능을 변경한 경우, 1. 기존 기능의 작동, 2. 어떻게 고쳤는가, 3. 왜 고쳤는가를 포함해주세요. 필요에 따라 스크린샷도 첨부해주세요! -->

#209 모듈 분리 논의에 앞서 RAP 인터페이스 디자인을 변경합니다.

클라이언트 관점에서(라이브러리를 사용하는 관점) 가장 큰 변화는 AnalyticsProvider 사용 방법이 달라졌다는 점입니다. 그 외에 Product Analytics(이하 PA) 별 지원(확장?) 모듈 구현 방식에 영향을 미치는 변화가 있으며 몇몇 함수와 인터페이스 이름이 바뀌었습니다. 

커밋 단위로 확인해주세요. 커밋은 작게 쪼갰으나 PR이 큽니다. 작업물 병합 목적이라기 보다는, 생각하는 방향을 보여주기 위한 목적으로 작성된 PR이기 때문입니다.

### 작업 내용

1. AnalyticsProviderContext 인터페이스의 역할과 메서드 이름을 변경합니다. 인터페이스 이름도 Analytics로 변경했고 core 폴더로 이동시켰습니다.

    - ProviderContext라는 표현이 불필요해 보여서 지웠습니다. 리액트에서 많이 쓰는 관례인가요? 저는 리액트를 잘 모릅니다 🙏
    - Analytics 인터페이스와 구현체는 리액트 의존이 없기 때문에 Svelte, Angular, Vue.js 어디서든 쓸 수 있습니다.
    - PA 별 지원 모듈은 Analytics 인터페이스의 구현체를 제공하면 됩니다.

        ```typescript
        class GoogleAnalytics implements Analytics { /* ... */ }
        class AmplitudeAnalytics implements Analytics { /* ... */ }
        class FirebaseAnalytics implements Analytics { /* ... */ }
        class AppsFlyerAnalytics implements Analytics { /* ... */ }
        ```

2. useAnalyticsContext 이름을 useAnalytics 으로 변경합니다.

    - Context라는 표현이 불필요해 보여서 지웠습니다. 리액트에서 많이 쓰는 관례인가요? 저는 리액트를 잘 모릅니다 🙏 
    - 이제 다음과 같이 쓸 수 있습니다

        ```patch
        - const analytics: AnalyticsProviderContext = useAnalyticsContext()
        + const analytics: Analytics = useAnalytics()
        ```

3. AnalyticsProvider의 Props 구조를 변경합니다.

    - analytics와 child node만을 가지도록 수정했습니다.
    - 다음과 같이 PA 지원 모듈이 제공한 구현체를 Composite 패턴으로 조립해서 사용하면 편리할 것 같습니다.

        ```typescript
        const analytics: Analytics = new CompositeAnalytics( // core가 제공하는 클래스
            new GoogleAnalytics(), // google analytics 지원 모듈이 제공하는 클래스(네이밍이 조금 아쉽네요)
            new AmplitudeAnalytics(), // amplitude 지원 모듈이 제공하는 클래스
            new FirebaseAnalytics(), // firebase 지원 모듈이 제공하는 클래스
            new AppsFlyerAnalytics(), // appsflyer 지원 모듈이 제공하는 클래스
            new DebugAnalytics(), // 콘솔 로그를 남기거나 Toast를 표시하는 클래스. core가 제공하거나 라이브러리 사용자가 직접 정의해도 됨
        )
        <AnalyticsProvider analytics={analytics}>
        ```

## Help Wanted 👀

next.js 데모 앱 작동을 확인하지 못 했습니다. 빌드가 안 되네요. 루트 디렉토리에서 `npm install && npm run serve`를 실행한 뒤에, next.js 데모 프로젝트 디렉토리에서 `npm install && npm run build`를 실행했습니다. 그랬더니 다음과 같은 오류가 뜹니다 :cry:

```
ReferenceError: window is not defined
    at /Users/kimdonghyeon/repos/EveryAnalytics/react-analytics-provider/node_modules/amplitude-js/amplitude.umd.js:1197:12
    at /Users/kimdonghyeon/repos/EveryAnalytics/react-analytics-provider/node_modules/amplitude-js/amplitude.umd.js:2:83
    at Object.<anonymous> (/Users/kimdonghyeon/repos/EveryAnalytics/react-analytics-provider/node_modules/amplitude-js/amplitude.umd.js:5:2)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.411 (/Users/kimdonghyeon/repos/EveryAnalytics/react-analytics-provider/demo/with-nextjs/.next/server/pages/_app.js:150:18) {
  type: 'ReferenceError'
```

## Related Issues

related #209

## Checklist ✋

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`yarn build`, `yarn test`)
- [ ] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)