### PR TITLE
refactor: Implement new analytics class to react context

### DIFF
--- a/src/components/AnalyticsClick/index.tsx
+++ b/src/components/AnalyticsClick/index.tsx
@@ -9,13 +9,13 @@ export interface AnalyticsClickProps {
 }
 
 export const AnalyticsClick = ({children, name, params}: AnalyticsClickProps) => {
-  const {onClick} = useAnalyticsContext();
+  const analytics = useAnalyticsContext();
 
   const child = React.Children.only(children) as React.ReactElement;
 
   const handleChildClick = useCallback(() => {
-    onClick(name, {action_type: 'click', ...params});
-  }, [name, params, onClick]);
+    analytics.click(name, {action_type: 'click', ...params});
+  }, [name, params, analytics]);
 
   return React.cloneElement(child, {
     onClick: handleChildClick,

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import {useAnalyticsContext} from '../../contexts/useAnalyticsContext';
-import {UnknownRecord} from '../../types/common';
 
 export interface AnalyticsPageViewProps {
   children: React.ReactNode;
-  params: UnknownRecord;
+  params: string;
 }
 
 export const AnalyticsPageView = ({children, params}: AnalyticsPageViewProps) => {
   const analytics = useAnalyticsContext();
 
   React.useEffect(() => {
-    analytics.onPageView(params);
+    analytics.pageView(params);
   }, [analytics, params]);
 
   return <>{children}</>;

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useAnalyticsContext} from '../../contexts/useAnalyticsContext';
 
 export interface AnalyticsPageViewProps {
@@ -9,7 +9,7 @@ export interface AnalyticsPageViewProps {
 export const AnalyticsPageView = ({children, pathname}: AnalyticsPageViewProps) => {
   const analytics = useAnalyticsContext();
 
-  React.useEffect(() => {
+  useEffect(() => {
     analytics.pageView(pathname);
   }, [analytics, pathname]);
 

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -1,17 +1,18 @@
 import React, {useEffect} from 'react';
 import {useAnalyticsContext} from '../../contexts/useAnalyticsContext';
+import {Pathname, UnknownRecord} from '../../types';
 
 export interface AnalyticsPageViewProps {
   children: React.ReactNode;
-  pathname: string;
+  params: Pathname | UnknownRecord;
 }
 
-export const AnalyticsPageView = ({children, pathname}: AnalyticsPageViewProps) => {
+export const AnalyticsPageView = ({children, params}: AnalyticsPageViewProps) => {
   const analytics = useAnalyticsContext();
 
   useEffect(() => {
-    analytics.pageView(pathname);
-  }, [analytics, pathname]);
+    analytics.pageView(params);
+  }, [analytics, params]);
 
   return <>{children}</>;
 };

--- a/src/components/AnalyticsPageView/index.tsx
+++ b/src/components/AnalyticsPageView/index.tsx
@@ -3,15 +3,15 @@ import {useAnalyticsContext} from '../../contexts/useAnalyticsContext';
 
 export interface AnalyticsPageViewProps {
   children: React.ReactNode;
-  params: string;
+  pathname: string;
 }
 
-export const AnalyticsPageView = ({children, params}: AnalyticsPageViewProps) => {
+export const AnalyticsPageView = ({children, pathname}: AnalyticsPageViewProps) => {
   const analytics = useAnalyticsContext();
 
   React.useEffect(() => {
-    analytics.pageView(params);
-  }, [analytics, params]);
+    analytics.pageView(pathname);
+  }, [analytics, pathname]);
 
   return <>{children}</>;
 };

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -2,16 +2,16 @@ import React, {useEffect, useMemo} from 'react';
 
 import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
 import {Analytics} from '../../mixin/analytics';
-import {IAnalyticsClient} from '../../interfaces';
-import {SetUpParams} from '../../types';
+import {AnalyticsClient} from '../../interfaces';
+import {SetupParams} from '../../types';
 
 export type AnalyticsProviderProps = {
   children: React.ReactNode;
 } & (
   | {
-      client: IAnalyticsClient;
+      client: AnalyticsClient;
     }
-  | {setup: SetUpParams}
+  | {setup: SetupParams}
 );
 
 export function AnalyticsProvider(props: AnalyticsProviderProps) {

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -1,51 +1,27 @@
 import * as React from 'react';
 
 import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
-import {UnknownRecord} from '../../types/common';
-
-interface Props {
-  onInitialize(): void;
-  onPageView?(params?: UnknownRecord): void;
-  onEvent?(name: string, params?: UnknownRecord): void;
-  onClick?(name: string, params?: UnknownRecord): void;
-  onSet?(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId?(userId: string | null): void;
-  onSetUserProperty?(params: UnknownRecord): void;
-  onException(params?: UnknownRecord): void;
-  children: React.ReactNode;
-}
+import {Analytics} from '../../mixin/analytics';
+import {IAnalyticsClient} from '../../interfaces';
+import {SetUpParams} from '../../types';
 
 export function AnalyticsProvider({
-  onInitialize,
-  onPageView = () => null,
-  onEvent = () => null,
-  onClick = () => null,
-  onSet = () => null,
-  onSetUserId = () => null,
-  onSetUserProperty = () => null,
-  onException = () => null,
+  initialAnalyticsProps,
   children,
-}: Props) {
+}: {
+  initialAnalyticsProps: IAnalyticsClient | SetUpParams;
+  children: React.ReactNode;
+}) {
   React.useEffect(() => {
-    onInitialize();
-  }, [onInitialize]);
+    if ('init' in initialAnalyticsProps) {
+      Analytics.preset(initialAnalyticsProps);
+    } else {
+      Analytics.setup(initialAnalyticsProps);
+    }
+  }, [initialAnalyticsProps]);
 
   return React.useMemo(
-    () => (
-      <AnalyticsProviderContext.Provider
-        value={{
-          onPageView,
-          onEvent,
-          onClick,
-          onSet,
-          onSetUserId,
-          onSetUserProperty,
-          onException,
-        }}
-      >
-        {children}
-      </AnalyticsProviderContext.Provider>
-    ),
-    [children, onClick, onEvent, onPageView, onSet, onSetUserId, onSetUserProperty, onException],
+    () => <AnalyticsProviderContext.Provider value={Analytics}>{children}</AnalyticsProviderContext.Provider>,
+    [children],
   );
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -1,25 +1,37 @@
-import React, {useEffect, useMemo} from 'react';
+import React, {useEffect, useMemo, ReactNode} from 'react';
 
 import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
 import {Analytics} from '../../mixin/analytics';
 import {AnalyticsClient} from '../../interfaces';
 import {SetupParams} from '../../types';
 
-export type AnalyticsProviderProps = {
-  children: React.ReactNode;
-} & (
-  | {
-      client: AnalyticsClient;
-    }
-  | {setup: SetupParams}
-);
+interface CustomSetupProps {
+  children: ReactNode;
+  client: AnalyticsClient;
+}
+
+interface DefaultSetupProps {
+  children: ReactNode;
+  setup: SetupParams;
+}
+
+export type AnalyticsProviderProps = CustomSetupProps | DefaultSetupProps;
+
+const isCustomSetup = (props: AnalyticsProviderProps): props is CustomSetupProps =>
+  (props as CustomSetupProps).client !== undefined;
+
+const isDefaultSetup = (props: AnalyticsProviderProps): props is DefaultSetupProps =>
+  (props as DefaultSetupProps).setup !== undefined;
 
 export function AnalyticsProvider(props: AnalyticsProviderProps) {
   useEffect(() => {
-    if ('client' in props) {
+    if (isCustomSetup(props)) {
       Analytics.preset(props.client);
-    } else {
+      return;
+    }
+    if (isDefaultSetup(props)) {
       Analytics.setup(props.setup);
+      return;
     }
   }, [props]);
 

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -5,12 +5,12 @@ import {Analytics} from '../../mixin/analytics';
 import {AnalyticsClient} from '../../interfaces';
 import {SetupParams} from '../../types';
 
-interface CustomSetupProps {
+export interface CustomSetupProps {
   children: ReactNode;
   client: AnalyticsClient;
 }
 
-interface DefaultSetupProps {
+export interface DefaultSetupProps {
   children: ReactNode;
   setup: SetupParams;
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -5,23 +5,26 @@ import {Analytics} from '../../mixin/analytics';
 import {IAnalyticsClient} from '../../interfaces';
 import {SetUpParams} from '../../types';
 
-export function AnalyticsProvider({
-  initialAnalyticsProps,
-  children,
-}: {
-  initialAnalyticsProps: IAnalyticsClient | SetUpParams;
+export type AnalyticsProviderProps = {
   children: React.ReactNode;
-}) {
-  React.useEffect(() => {
-    if ('init' in initialAnalyticsProps) {
-      Analytics.preset(initialAnalyticsProps);
-    } else {
-      Analytics.setup(initialAnalyticsProps);
+} & (
+  | {
+      client: IAnalyticsClient;
     }
-  }, [initialAnalyticsProps]);
+  | {setup: SetUpParams}
+);
+
+export function AnalyticsProvider(props: AnalyticsProviderProps) {
+  React.useEffect(() => {
+    if ('client' in props) {
+      Analytics.preset(props.client);
+    } else {
+      Analytics.setup(props.setup);
+    }
+  }, [props]);
 
   return React.useMemo(
-    () => <AnalyticsProviderContext.Provider value={Analytics}>{children}</AnalyticsProviderContext.Provider>,
-    [children],
+    () => <AnalyticsProviderContext.Provider value={Analytics}>{props.children}</AnalyticsProviderContext.Provider>,
+    [props.children],
   );
 }

--- a/src/components/AnalyticsProvider/index.tsx
+++ b/src/components/AnalyticsProvider/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, {useEffect, useMemo} from 'react';
 
 import AnalyticsProviderContext from '../../contexts/AnalyticsProviderContext';
 import {Analytics} from '../../mixin/analytics';
@@ -15,7 +15,7 @@ export type AnalyticsProviderProps = {
 );
 
 export function AnalyticsProvider(props: AnalyticsProviderProps) {
-  React.useEffect(() => {
+  useEffect(() => {
     if ('client' in props) {
       Analytics.preset(props.client);
     } else {
@@ -23,7 +23,7 @@ export function AnalyticsProvider(props: AnalyticsProviderProps) {
     }
   }, [props]);
 
-  return React.useMemo(
+  return useMemo(
     () => <AnalyticsProviderContext.Provider value={Analytics}>{props.children}</AnalyticsProviderContext.Provider>,
     [props.children],
   );

--- a/src/contexts/AnalyticsProviderContext.ts
+++ b/src/contexts/AnalyticsProviderContext.ts
@@ -1,26 +1,7 @@
 import {createContext} from 'react';
-import {UnknownRecord} from '../types/common';
 
-export interface AnalyticsProviderContext {
-  onPageView(params?: UnknownRecord): void;
-  onEvent(name: string, params?: UnknownRecord): void;
-  onClick(name: string, params?: UnknownRecord): void;
-  onSet(...args: [string, UnknownRecord] | [UnknownRecord]): void;
-  onSetUserId(userId: string | null): void;
-  onSetUserProperty(params: UnknownRecord): void;
-  onException(params?: UnknownRecord): void;
-}
+import {Analytics} from '../mixin';
 
-export const initialState: AnalyticsProviderContext = {
-  onPageView: () => null,
-  onEvent: () => null,
-  onClick: () => null,
-  onSet: () => null,
-  onSetUserId: () => null,
-  onSetUserProperty: () => null,
-  onException: () => null,
-};
-
-const AnalyticsProviderContext = createContext<AnalyticsProviderContext>(initialState);
+const AnalyticsProviderContext = createContext<typeof Analytics>(Analytics);
 
 export default AnalyticsProviderContext;

--- a/src/hooks/useAnalyticsPageView.ts
+++ b/src/hooks/useAnalyticsPageView.ts
@@ -1,16 +1,15 @@
 import React from 'react';
 import {useAnalyticsContext} from '../contexts/useAnalyticsContext';
-import {UnknownRecord} from '../types/common';
 
-export function useAnalyticsPageView(params: UnknownRecord): void;
-export function useAnalyticsPageView(callback: () => UnknownRecord): void;
-export function useAnalyticsPageView(callback: () => Promise<UnknownRecord>): void;
-export function useAnalyticsPageView(paramsOrCallback: UnknownRecord | (() => Promise<UnknownRecord> | UnknownRecord)) {
+export function useAnalyticsPageView(params: string): void;
+export function useAnalyticsPageView(callback: () => string): void;
+export function useAnalyticsPageView(callback: () => Promise<string>): void;
+export function useAnalyticsPageView(paramsOrCallback: string | (() => Promise<string> | string)) {
   const analytics = useAnalyticsContext();
 
   const pageView = async () => {
     const params = typeof paramsOrCallback === 'function' ? await paramsOrCallback() : paramsOrCallback;
-    analytics.onPageView(params);
+    analytics.pageView(params);
   };
 
   React.useEffect(() => {

--- a/src/hooks/useAnalyticsPageView.ts
+++ b/src/hooks/useAnalyticsPageView.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useEffect} from 'react';
 import {useAnalyticsContext} from '../contexts/useAnalyticsContext';
 
 export function useAnalyticsPageView(pathname: string): void;
@@ -12,7 +12,7 @@ export function useAnalyticsPageView(pathnameOrCallback: string | (() => Promise
     analytics.pageView(pathname);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     pageView();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [analytics]);

--- a/src/hooks/useAnalyticsPageView.ts
+++ b/src/hooks/useAnalyticsPageView.ts
@@ -1,15 +1,15 @@
 import React from 'react';
 import {useAnalyticsContext} from '../contexts/useAnalyticsContext';
 
-export function useAnalyticsPageView(params: string): void;
+export function useAnalyticsPageView(pathname: string): void;
 export function useAnalyticsPageView(callback: () => string): void;
 export function useAnalyticsPageView(callback: () => Promise<string>): void;
-export function useAnalyticsPageView(paramsOrCallback: string | (() => Promise<string> | string)) {
+export function useAnalyticsPageView(pathnameOrCallback: string | (() => Promise<string> | string)) {
   const analytics = useAnalyticsContext();
 
   const pageView = async () => {
-    const params = typeof paramsOrCallback === 'function' ? await paramsOrCallback() : paramsOrCallback;
-    analytics.pageView(params);
+    const pathname = typeof pathnameOrCallback === 'function' ? await pathnameOrCallback() : pathnameOrCallback;
+    analytics.pageView(pathname);
   };
 
   React.useEffect(() => {

--- a/src/interfaces/analytics-client.interface.ts
+++ b/src/interfaces/analytics-client.interface.ts
@@ -1,11 +1,11 @@
-import {UnknownRecord} from '../types/common';
+import {Pathname, UnknownRecord} from '../types/common';
 
 export interface AnalyticsClient {
   init: () => void | Promise<void>;
 
   event: (name: string, data?: UnknownRecord, callback?: (...args: unknown[]) => void) => void;
 
-  pageView?: (pathname: string) => void;
+  pageView?: (data: Pathname | UnknownRecord) => void;
   click?: (eventName: string, data?: UnknownRecord) => void;
 
   setUserId?: (id: string | number) => void;

--- a/src/interfaces/analytics-client.interface.ts
+++ b/src/interfaces/analytics-client.interface.ts
@@ -1,6 +1,6 @@
 import {UnknownRecord} from '../types/common';
 
-export interface IAnalyticsClient {
+export interface AnalyticsClient {
   init: () => void | Promise<void>;
 
   event: (name: string, data?: UnknownRecord, callback?: (...args: unknown[]) => void) => void;

--- a/src/mixin/analytics.ts
+++ b/src/mixin/analytics.ts
@@ -1,6 +1,6 @@
 import {AnalyticsClient} from '../interfaces';
 import {googleAnalyticsHelper, amplitudeHelper} from '../utils';
-import {UnknownRecord, SetupParams} from '../types';
+import {UnknownRecord, SetupParams, Pathname} from '../types';
 
 export class Analytics {
   static googleAnalytics = googleAnalyticsHelper;
@@ -85,12 +85,12 @@ export class Analytics {
     client.click?.(eventName, data);
   }
 
-  static pageView(pathname: string) {
+  static pageView(data: Pathname | UnknownRecord) {
     const client = this.getClient();
     if (!client) {
       return;
     }
-    client.pageView?.(pathname);
+    client.pageView?.(data);
   }
 
   static setUserId(id: string | number) {

--- a/src/mixin/analytics.ts
+++ b/src/mixin/analytics.ts
@@ -1,20 +1,20 @@
-import {IAnalyticsClient} from '../interfaces';
+import {AnalyticsClient} from '../interfaces';
 import {googleAnalyticsHelper, amplitudeHelper} from '../utils';
-import {UnknownRecord, SetUpParams} from '../types';
+import {UnknownRecord, SetupParams} from '../types';
 
 export class Analytics {
   static googleAnalytics = googleAnalyticsHelper;
   static amplitude = amplitudeHelper;
 
   static isInitialized = false;
-  static client: IAnalyticsClient;
+  static client: AnalyticsClient;
 
   static clear() {
     this.isInitialized = false;
     this.client = null;
   }
 
-  static setup(params: SetUpParams) {
+  static setup(params: SetupParams) {
     const {googleAnalytics, amplitude} = params;
 
     this.preset({
@@ -45,13 +45,13 @@ export class Analytics {
     });
   }
 
-  static preset(client: IAnalyticsClient) {
+  static preset(client: AnalyticsClient) {
     this.clear();
     this.client = Object.freeze(client);
     this.init();
   }
 
-  static getClient(): IAnalyticsClient | void {
+  static getClient(): AnalyticsClient | void {
     if (!this.client) {
       console.warn('preset이 실행되지 않았습니다.');
       return;

--- a/src/mixin/analytics.ts
+++ b/src/mixin/analytics.ts
@@ -20,7 +20,7 @@ export class Analytics {
     this.preset({
       init: () => {
         if (googleAnalytics) {
-          this.googleAnalytics.initialize(googleAnalytics.trakingId, googleAnalytics.persistentValues);
+          this.googleAnalytics.initialize(googleAnalytics.trackingId, googleAnalytics.persistentValues);
         }
         if (amplitude) {
           this.amplitude.initialize(amplitude.apiKey, amplitude.userId, amplitude.config, amplitude.callback);
@@ -36,7 +36,7 @@ export class Analytics {
       },
       pageView: (pathname: string) => {
         if (googleAnalytics) {
-          this.googleAnalytics.pageView(googleAnalytics.trakingId, pathname);
+          this.googleAnalytics.pageView(googleAnalytics.trackingId, pathname);
         }
         if (amplitude) {
           this.amplitude.logEvent('pageView', {pathname});

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,1 +1,3 @@
 export type UnknownRecord = Record<string, unknown>;
+
+export type Pathname = string;

--- a/src/types/set-up-params.ts
+++ b/src/types/set-up-params.ts
@@ -1,7 +1,7 @@
 import type {AmplitudeClient, Config} from 'amplitude-js';
 
 export type GoogleAnalyticsSetUpParams = {
-  trakingId: string;
+  trackingId: string;
   persistentValues?: Record<string, unknown>;
 };
 

--- a/src/types/set-up-params.ts
+++ b/src/types/set-up-params.ts
@@ -1,18 +1,18 @@
 import type {AmplitudeClient, Config} from 'amplitude-js';
 
-export type GoogleAnalyticsSetUpParams = {
+export type GoogleAnalyticsSetupParams = {
   trackingId: string;
   persistentValues?: Record<string, unknown>;
 };
 
-export type AmplitudeSetUpParams = {
+export type AmplitudeSetupParams = {
   apiKey: string;
   userId?: string;
   config?: Config;
   callback?: (client: AmplitudeClient) => void;
 };
 
-export type SetUpParams = {
-  googleAnalytics?: GoogleAnalyticsSetUpParams;
-  amplitude?: AmplitudeSetUpParams;
+export type SetupParams = {
+  googleAnalytics?: GoogleAnalyticsSetupParams;
+  amplitude?: AmplitudeSetupParams;
 };

--- a/tests/hooks/useAnalyticsPageView.test.ts
+++ b/tests/hooks/useAnalyticsPageView.test.ts
@@ -6,7 +6,7 @@ import {useAnalyticsPageView} from '../../src/hooks/useAnalyticsPageView';
 
 describe('useAnalyticsPageView', () => {
   const setUp = () => {
-    const params = {value: faker.lorem.word()};
+    const params = faker.lorem.word();
     const callback = () => params;
     const asyncCallback = async () => params;
 

--- a/tests/hooks/useAnalyticsPageView.test.ts
+++ b/tests/hooks/useAnalyticsPageView.test.ts
@@ -10,13 +10,13 @@ describe('useAnalyticsPageView', () => {
     const callback = () => params;
     const asyncCallback = async () => params;
 
-    const onPageView = jest.fn();
+    const pageView = jest.fn();
 
     const useEffectSpy = jest.spyOn(React, 'useEffect').mockImplementationOnce(cb => cb());
     const useContextSpy = jest.spyOn(contextModule, 'useAnalyticsContext').mockImplementationOnce(
       () =>
         ({
-          onPageView,
+          pageView,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any),
     );
@@ -26,7 +26,7 @@ describe('useAnalyticsPageView', () => {
       params,
       callback,
       asyncCallback,
-      onPageView,
+      pageView,
       useEffectSpy,
       useContextSpy,
     };
@@ -35,35 +35,35 @@ describe('useAnalyticsPageView', () => {
   const waitForAsync = () => new Promise(resolve => setTimeout(resolve, 0));
 
   test('should call analytics.onPageView with params', async () => {
-    const {params, onPageView, useContextSpy, useEffectSpy} = setUp();
+    const {params, pageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(params);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(pageView).toHaveBeenCalledWith(params);
   });
 
   test('should call analytics.onPageView with callback', async () => {
-    const {params, callback, onPageView, useContextSpy, useEffectSpy} = setUp();
+    const {params, callback, pageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(callback);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(pageView).toHaveBeenCalledWith(params);
   });
 
   test('should call analytics.onPageView with asyncCallback', async () => {
-    const {params, asyncCallback, onPageView, useContextSpy, useEffectSpy} = setUp();
+    const {params, asyncCallback, pageView, useContextSpy, useEffectSpy} = setUp();
 
     useAnalyticsPageView(asyncCallback);
     await waitForAsync();
 
     expect(useContextSpy).toHaveBeenCalled();
     expect(useEffectSpy).toHaveBeenCalled();
-    expect(onPageView).toHaveBeenCalledWith(params);
+    expect(pageView).toHaveBeenCalledWith(params);
   });
 });


### PR DESCRIPTION
## Description

수민님 [PR](https://github.com/EveryAnalytics/react-analytics-provider/pull/225)로 적용된 새로운 Analytics 인터페이스를 적용해서 context에 넘겨주는 props 형태를 수정했습니다. 

## Help Wanted 👀

- 사용자가 simple setup을 원하는 경우/custom setup을 원하는 경우에 따라서 Provider 컴포넌트에 다른 props를 넘겨주고 내부에서 setup/preset을 호출하도록 했는데 괜찮을까유? 
- **변경된 구조에 맞추어 demo 수정이 필요합니다!**
- 테스트가 다 깨지는데 Jest를 사용해본 적이 없어서 도움이 필요합니다ㅠㅠ @greatSumini 



## Related Issues

resolve #
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`yarn build`, `yarn test`)
- [ ] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)